### PR TITLE
DEV-18558 Called multiadapter "registerCheckResult"

### DIFF
--- a/src/adapters/AutoBindAdapter.ts
+++ b/src/adapters/AutoBindAdapter.ts
@@ -53,6 +53,7 @@ export class AutoBindAdapter implements AdapterInterface {
   }
 
   registerCheckResult(_checkResult: SuccessfulCheckResult) {
+    this.multiAdapter.registerCheckResult(_checkResult);
   }
 
   selectRanges(checkId: string, matches: Match[]) {


### PR DESCRIPTION
Hi Ralf, Hi Marco,

Subject: Lookup fails for browser extensions. 
With changes made for introducing  two models in[ DEV-17470](https://acrolinx.atlassian.net/browse/DEV-17470) we introduced "adaptersOfLastSuccessfulCheck". This member need to initialized by autobind adapter on "registerCheckResult".

Could you please review the change and let me know if its ok or any other suggestion you have?

Thanks,
Abhijeet