### PR TITLE
Support shadow dom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tmp
 
 **/.baseDir.ts
 /dist/
+
+coverage

--- a/src/autobind/autobind.ts
+++ b/src/autobind/autobind.ts
@@ -74,8 +74,18 @@ function traverseIFrames(el: Element): Element[] {
   }
 }
 
-function getEditableElements(doc: Document = document): Element[] {
+function traverseShadowRoots(el: Element): Element[] {
+  if (el.shadowRoot) {
+    return el.shadowRoot ? getEditableElements(el.shadowRoot) : [];
+  } else {
+    return [];
+  }
+}
+
+function getEditableElements(doc: Document | ShadowRoot = document): Element[] {
   return _(doc.querySelectorAll(EDITABLE_ELEMENTS_SELECTOR))
+    .union(_(doc.querySelectorAll('*'))
+    .flatMap(traverseShadowRoots).value())
     .flatMap(traverseIFrames)
     .reject(el => isReadOnly(el) || isProbablyCombobox(el) || isProbablySearchField(el))
     .value();

--- a/src/autobind/autobind.ts
+++ b/src/autobind/autobind.ts
@@ -74,18 +74,16 @@ function traverseIFrames(el: Element): Element[] {
   }
 }
 
-function traverseShadowRoots(el: Element): Element[] {
-  if (el.shadowRoot) {
-    return el.shadowRoot ? getEditableElements(el.shadowRoot) : [];
-  } else {
-    return [];
-  }
+function traverseShadowRoots(doc: Document | ShadowRoot): Element[] {
+  return _(doc.querySelectorAll('*'))
+    .flatMap(el => el.shadowRoot ? getEditableElements(el.shadowRoot) : [])
+    .value();
 }
 
-function getEditableElements(doc: Document | ShadowRoot = document): Element[] {
+// Exported mainly for testing
+export function getEditableElements(doc: Document | ShadowRoot = document): Element[] {
   return _(doc.querySelectorAll(EDITABLE_ELEMENTS_SELECTOR))
-    .union(_(doc.querySelectorAll('*'))
-    .flatMap(traverseShadowRoots).value())
+    .union(traverseShadowRoots(doc))
     .flatMap(traverseIFrames)
     .reject(el => isReadOnly(el) || isProbablyCombobox(el) || isProbablySearchField(el))
     .value();

--- a/test/spec/autobind.ts
+++ b/test/spec/autobind.ts
@@ -143,6 +143,23 @@ describe('autobind', function () {
     assert.equal(adapters.length, 3);
   });
 
+  it('dont bind closed shadow root fields', () => {
+    setPageContent(`
+          <div id="container"></div>
+          <script>
+            (() => {
+              const root = container.attachShadow({ mode: "closed" });
+              const element = document.createElement("input")
+              element.setAttribute("type", "text");
+              root.appendChild(element);
+            })();
+          </script>
+      `);
+
+    const adapters = bindAdaptersForCurrentPage();
+    assert.equal(adapters.length, 0);
+  });
+
   it('dont bind fields that are probably comboboxes', () => {
     setPageContent(`
           <input role="combobox" autocomplete="off"/>

--- a/test/spec/autobind.ts
+++ b/test/spec/autobind.ts
@@ -98,6 +98,51 @@ describe('autobind', function () {
     assert.equal(adapters.length, 0);
   });
 
+  it('bind shadow root fields', () => {
+    setPageContent(`
+          <div id="container"></div>
+          <script>
+            (() => {
+              const root = container.attachShadow({ mode: "open" });
+              const element = document.createElement("input")
+              element.setAttribute("type", "text");
+              root.appendChild(element);
+            })();
+          </script>
+      `);
+
+    const adapters = bindAdaptersForCurrentPage();
+    assert.equal(adapters.length, 1);
+  });
+
+  it('bind nested shadow root fields', () => {
+    setPageContent(`
+          <div id="container"></div>
+          <input type="text"></input>
+          <script>
+            (() => {
+              const root = container.attachShadow({ mode: "open" });
+              const inputElement = document.createElement("input");
+              inputElement.setAttribute("type", "text");
+
+              // Add a nested shadow
+              const innerContainer = document.createElement("div");
+              innerContainer.setAttribute("id", "innerContainer");
+              const nestedRoot = innerContainer.attachShadow({ mode: "open" });
+              const inputElementNested = document.createElement("input");
+              inputElementNested.setAttribute("type", "text");
+              nestedRoot.appendChild(inputElementNested);
+
+              root.appendChild(inputElement);
+              root.appendChild(innerContainer);
+            })();
+          </script>
+      `);
+
+    const adapters = bindAdaptersForCurrentPage();
+    assert.equal(adapters.length, 3);
+  });
+
   it('dont bind fields that are probably comboboxes', () => {
     setPageContent(`
           <input role="combobox" autocomplete="off"/>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 // MAX_SIZE_IN_BYTES is set here as a warning to avoid avoid accidental bloat.
 // If it gets bigger and there is no way to avoid it, we must increase this number sadly.
-const MAX_SIZE_IN_BYTES = 495 * 1024;
+const MAX_SIZE_IN_BYTES = 496 * 1024;
 
 module.exports = {
   mode: 'production',


### PR DESCRIPTION
Support for shadow dom.

Fix: Added a recursive loop over all elements to check presence of shadow root.

Tests: 
1. Element inside shadow dom 
2. Element inside nested shadow dom
3. Closed shadow unsupported.