### PR TITLE
DEV-30719; fix: add test setup for CK5

### DIFF
--- a/.coverage.json
+++ b/.coverage.json
@@ -1,6 +1,6 @@
 {
-  "statements": 79,
-  "branches": 65,
+  "statements": 78.76,
+  "branches": 64.66,
   "functions": 75,
   "lines": 79
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
       "dependencies": {
         "@acrolinx/sidebar-startpage": "^3.1.0",
         "@types/ckeditor": "4.9.10",
+        "@types/ckeditor__ckeditor5-build-balloon": "^29.1.1",
+        "@types/ckeditor__ckeditor5-build-classic": "^29.0.1",
+        "@types/ckeditor__ckeditor5-build-inline": "^29.0.0",
+        "@types/ckeditor__ckeditor5-core": "^33.0.3",
         "@types/codemirror": "0.0.106",
         "@types/diff-match-patch": "^1.0.32",
         "@types/tinymce": "^4.6.0",
@@ -22,6 +26,7 @@
       },
       "devDependencies": {
         "@acrolinx/sidebar-interface": "^15.0.0",
+        "@ckeditor/ckeditor5-build-inline": "^35.0.1",
         "@types/chai": "^4.3.0",
         "@types/draft-js": "^0.11.8",
         "@types/jquery": "^3.5.13",
@@ -399,6 +404,465 @@
         "node": ">=4"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-35.0.1.tgz",
+      "integrity": "sha512-TASf7EnSw0ndTwTGWUBsFz9lZpQvXeEv/8icGwwBOlDe5arj/v4Xk9kqyWysXi6Mv/PTEpVEXV8xrAPX7oHpbg==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-35.0.1.tgz",
+      "integrity": "sha512-Q/dWKR3IASmlSRC7GY14hWJ6t1alKG5+9gPvGfF2qQhvKYkGdUEdvhiUs2xcvRuIOzR4nszYvy9Kj9j+NReBRQ==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-35.0.1.tgz",
+      "integrity": "sha512-Srg5Kbb5Gux+xTu24Wp+R/NbFUTM36bU/hgxSzfERvQgeDAp7TMdf2O/BCLrm6aTVHowgnUOFsH5PgnuG+rxsQ==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-35.0.1.tgz",
+      "integrity": "sha512-s4ef9M/1SHAT2e0nK3AHSWmN8CpK5VUfYBa5hXey8QycTaLVxAbOs+jxki6+KJHlozikJ+BxXNj03CWROrR/Tw==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-inline/-/ckeditor5-build-inline-35.0.1.tgz",
+      "integrity": "sha512-ellVKLUNaCrTMuleWwRB64GG8lM4Mc4TGpyfSrc8nvuuaBnzkSBD+ybLqIBaYl4d1lfGPo7glF+gURfqcLEiNg==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "^35.0.1",
+        "@ckeditor/ckeditor5-autoformat": "^35.0.1",
+        "@ckeditor/ckeditor5-basic-styles": "^35.0.1",
+        "@ckeditor/ckeditor5-block-quote": "^35.0.1",
+        "@ckeditor/ckeditor5-ckbox": "^35.0.1",
+        "@ckeditor/ckeditor5-ckfinder": "^35.0.1",
+        "@ckeditor/ckeditor5-cloud-services": "^35.0.1",
+        "@ckeditor/ckeditor5-easy-image": "^35.0.1",
+        "@ckeditor/ckeditor5-editor-inline": "^35.0.1",
+        "@ckeditor/ckeditor5-essentials": "^35.0.1",
+        "@ckeditor/ckeditor5-heading": "^35.0.1",
+        "@ckeditor/ckeditor5-image": "^35.0.1",
+        "@ckeditor/ckeditor5-indent": "^35.0.1",
+        "@ckeditor/ckeditor5-link": "^35.0.1",
+        "@ckeditor/ckeditor5-list": "^35.0.1",
+        "@ckeditor/ckeditor5-media-embed": "^35.0.1",
+        "@ckeditor/ckeditor5-paragraph": "^35.0.1",
+        "@ckeditor/ckeditor5-paste-from-office": "^35.0.1",
+        "@ckeditor/ckeditor5-table": "^35.0.1",
+        "@ckeditor/ckeditor5-typing": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-35.0.1.tgz",
+      "integrity": "sha512-E0lYBPBMsOjYqEtBVlx6H47dHnnz9fcS6DvvXKs1Je8OKQNcEf/N8akGoD1lOx6E9C5zTrCln7UdY2JcIQhy+w==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-35.0.1.tgz",
+      "integrity": "sha512-Cy+esbIxhWJvEpls+FqNLqukQ6RKbFhqJPOfno6K9ePITImSu5H0bAMYYFgdiIQVduMuJzlpOrbUCJiU13GKFg==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-35.0.1.tgz",
+      "integrity": "sha512-XHBnR+v+GLXondSrJdpTLT3++0++Ja5gNC2zKdpDx6ykayQVYF0Nry+XoXbbzffnXYnRrWzo++r32ngW39rFUQ==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "@ckeditor/ckeditor5-widget": "^35.0.1",
+        "lodash-es": "^4.17.11"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-35.0.1.tgz",
+      "integrity": "sha512-/GXmhQ8/NHXv3V1Oh1MA/x9uKj1PrmC4CglE33mB9JfcL+y7gY0gRRjFykDXlijNhp5Ro1Av9OnHimXRHLYCUg==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-core": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-35.0.1.tgz",
+      "integrity": "sha512-yLX4WwyKjBbgINfl3wB8nyAtxclmP8FBVWunnHZ+YBq6KryB0uWcplP1Nomz/3uyask6k2YN/rSY0Lu9xJ9uyQ==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-35.0.1.tgz",
+      "integrity": "sha512-KVxc5MTkn+iSRKm8aUEilqAvwQnPQrpSUpvi13bgVIt/ueGQ/uCOYQRSEaCZbs9HWfEv/f/Q+WZ5hB+ocW57vg==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-35.0.1.tgz",
+      "integrity": "sha512-TvwG8RavE2+FkQtsuTMg8e1GdnHDC5m/YkIZEx5lo8ax71GoZP6ze9WipLYtvLmLD+yLnCCVp36/ZTkWcIsgCA==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-35.0.1.tgz",
+      "integrity": "sha512-Jz1sEBnFr06a1ezOqTbydClp9GgK/YL1CyvilCYIOoRiMevr1XMR3slsJCXC8AmHAcDn+PtxSniw+CREFZaTAA==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-35.0.1.tgz",
+      "integrity": "sha512-vNJzom2pSWyYrPk+VYjeSOBBeVI0B3P+DW1Vwyd3HfB1NKB7zU6T+7ByWwhvzdsv5xovzB+6X066lmUSV+W1fw==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-35.0.1.tgz",
+      "integrity": "sha512-uHfup2e2tETnuvJmHgey/JAYMdeK9eIe5VW2Ah4Q8Ndiu/Buajf+PFYWRFrnC8psaYyE3+vdHRwxV3SD/yZeKQ==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-35.0.1.tgz",
+      "integrity": "sha512-Rfc/Pa1EBQZIDFrLlL5HXx1gO3x0ZBq8DfeRlZ4Z6mRlOIzxU6Wj74qWsG6wauVJ1/KVVsghUN4zJ3U26SDaPQ==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-35.0.1.tgz",
+      "integrity": "sha512-DQWe8b+wwBkoyXcV16EeZc1+FWoEXQo+/0N5lI5P0g7YYGTak9IGio+yPppyILOeW+U+nXQ3ZYIhOQo+T+3FnA==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-35.0.1.tgz",
+      "integrity": "sha512-omD5EmhxAVLDRwSiq91NvNDkytF7RixyQrKOLH3XJ3W/ZtK++1fMBF5fyc0DdZdmTJX7B/8cA4paXfI8xNiEhg==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-35.0.1.tgz",
+      "integrity": "sha512-CJus1E3RvnkZ3VgEOsjYCvOePi/f+wlSZgRCrAD1IeUnjgzNMUMvAOO5QSeaR0CqqaBQcFoHRrVtCaBEIk21Yw==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-35.0.1.tgz",
+      "integrity": "sha512-8JaM+GILlTnJvKRJVcm+L7Wxo1lC179no6lfBV5Kyh+PRIWLiQi6gjX12AzRtFgn/tr/VKzfAKGaxf3etFPsFQ==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-35.0.1.tgz",
+      "integrity": "sha512-SIypYAgSmRURy4OkOyrcHsaK5FObFt4bEmRUXIlIXcHZAyi1qxUnHic3RcS6a4D1RbFPbKLwb1hCf3rLqJdB6g==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paragraph": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-35.0.1.tgz",
+      "integrity": "sha512-Ga+LWrXKDg6OXyPxBIaemgEfAKJlE40155IKsaeBHYZEVkS7eoDyuB5I3wFsmi8MRDrLwg6GDrBJ8bo/tKqmTg==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-35.0.1.tgz",
+      "integrity": "sha512-Fib3mlaRdBTyItOkPsvYB+0jW6DzsOEQ3hDuaMmx1Fz0DYPRG/XRQKjLPJcFGXpzIs4EedYHCb9P2M0dLaL5Ww==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-35.0.1.tgz",
+      "integrity": "sha512-I7oPF3LjL7etN1sxtpTshu47BGz6CNYHlLWcvPtU5QB+xvildQU1c5HboReufooZpYb8N898Zi8tHcd4/ij/8w==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-35.0.1.tgz",
+      "integrity": "sha512-XKZHGn/MbLfxIqdaVKD62DfOBUKPV0MlKhfpc941LENOb2qhqvmixhdlde7vVi+0k1HzumRj1BQFUOVvncAEiA==",
+      "dev": true,
+      "dependencies": {
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-35.0.1.tgz",
+      "integrity": "sha512-Yj3f8nv+iXsTxmnlTjFUk+Xcvd9OvtkFqsEgYdRA79TO71Gaigm2CLmi60wf39MtXc/hPCjhPSdvSk01CsNmQQ==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-35.0.1.tgz",
+      "integrity": "sha512-JFmHShOQ7tGDFKqH93Ba2U5sZQMOts0ho1OveHeaKpyG3mbsonBofWr/JacF/dpoNBi1pj8I7ssYR4bFVTwO+w==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-35.0.1.tgz",
+      "integrity": "sha512-zmO4JXCSd9JMikvjDGSvD3a2dAnlvTWMk2D8PSx5tNTj+MBm6pAbhqimeVdCQheBpAFQjH56ywKFZcYXJsXukA==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-35.0.1.tgz",
+      "integrity": "sha512-h/a7KM/StexPhbwcdjoYz7pcU86QLhNUw9pNdogR4L4OXUeDd0c6V0YWqaqbMc3HtC+N2+5tePwiV4Aw0NalNg==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-35.0.1.tgz",
+      "integrity": "sha512-H0ec3f963FpLPuLb58p4RbzkgiOYYNk7goNF4XVROZ4Vjf2dcGLJCDhUSHRBwz3cRL/zZ8a/f7HX/PBpYmnWlw==",
+      "dev": true,
+      "dependencies": {
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-35.0.1.tgz",
+      "integrity": "sha512-+XhPafSq/bRewa/cLddJGhon2lMsP9XuKsitSOogU0/LlyWNhyjcgUB2xPhGzfw5BO+CY1ptDBpgyw0lSxWOOw==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-enter": "^35.0.1",
+        "@ckeditor/ckeditor5-typing": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -572,6 +1036,594 @@
       "version": "4.9.10",
       "resolved": "https://registry.npmjs.org/@types/ckeditor/-/ckeditor-4.9.10.tgz",
       "integrity": "sha512-dcOPCXM0Cr5Z0i6eF/aW5LvECrS+cdl2Gi7lU+rEUNWby0w9Yl6mBubjrs29OVAducpuZjB4mfDayE+o4/gGdQ=="
+    },
+    "node_modules/@types/ckeditor__ckeditor5-adapter-ckfinder": {
+      "version": "29.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-adapter-ckfinder/-/ckeditor__ckeditor5-adapter-ckfinder-29.0.4.tgz",
+      "integrity": "sha512-baT+KeQG12qfu0iDu+TIy1BSM/OWzzvH8pTkSIckQhRwEt2mlW8jFNQMZGRi4kAmLabMoLvybiAn1yFDeepddw==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-upload": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-alignment": {
+      "version": "29.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-alignment/-/ckeditor__ckeditor5-alignment-29.0.7.tgz",
+      "integrity": "sha512-tZIF0svmHOHIvbnFM074b2CySBKKQxxZG5Y41UFAvkIYxel4LTZmFV3uTbdDTmniLRIbG219vOXtWHOJ5INB/A==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-autoformat": {
+      "version": "31.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-autoformat/-/ckeditor__ckeditor5-autoformat-31.0.1.tgz",
+      "integrity": "sha512-E2bDInIyq6J5slWDAruCRTCvWxCH1Gm91d70/V2+YKiwpzj0X0EXyIPTqO01xTbdjHbCy9XiGIZ7fVLDrzchNQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-autosave": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-autosave/-/ckeditor__ckeditor5-autosave-32.0.0.tgz",
+      "integrity": "sha512-auGeVgBG4HLXwPTbHQSsfGZcItntaBuBQN8LSreZea0ur4SJ6NKfh25USqIIQs1DUWYMDPiK6ODwSn2mhyfJ2A==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-basic-styles": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-basic-styles/-/ckeditor__ckeditor5-basic-styles-28.0.2.tgz",
+      "integrity": "sha512-ap6vMacs5rjcWRlHrYPsZPshHoPR7sruPgbuzduGQCy7X86SglOPwtd6XvMOMItslbLv1wYbJ3h9+S1kBOVvfA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-block-quote": {
+      "version": "29.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-block-quote/-/ckeditor__ckeditor5-block-quote-29.0.4.tgz",
+      "integrity": "sha512-FwNayTN7/8hdxCSA9cBiab4rEG3jERy+bF6qgr5pYwCiEthghlKT87IYqFYmVhznSsfqqR3KHi2a6GIfJMHpCA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-build-balloon": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-build-balloon/-/ckeditor__ckeditor5-build-balloon-29.1.1.tgz",
+      "integrity": "sha512-unvqLKPQ3ovQHNtCec0EbckUC432p5kC+8edcT99Fj2e2lCdQH9UBpi0RowH/p1VZ8Auflf2ebF1Vnu84Lr2UQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-autoformat": "*",
+        "@types/ckeditor__ckeditor5-basic-styles": "*",
+        "@types/ckeditor__ckeditor5-block-quote": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-easy-image": "*",
+        "@types/ckeditor__ckeditor5-editor-balloon": "*",
+        "@types/ckeditor__ckeditor5-essentials": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-list": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*",
+        "@types/ckeditor__ckeditor5-paste-from-office": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-build-classic": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-build-classic/-/ckeditor__ckeditor5-build-classic-29.0.1.tgz",
+      "integrity": "sha512-liWJN2v9xSJSLuU048nO7i7dr49T4REWhqSe7D7qcGcY3M5n7bVZnSNUnmBCB61WJg5iBl+KfwfdpDIDYp7+XQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-autoformat": "*",
+        "@types/ckeditor__ckeditor5-basic-styles": "*",
+        "@types/ckeditor__ckeditor5-block-quote": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-easy-image": "*",
+        "@types/ckeditor__ckeditor5-editor-classic": "*",
+        "@types/ckeditor__ckeditor5-essentials": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-list": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*",
+        "@types/ckeditor__ckeditor5-paste-from-office": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-build-inline": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-build-inline/-/ckeditor__ckeditor5-build-inline-29.0.0.tgz",
+      "integrity": "sha512-kWQlKmGuo7MVjwyIAXrf4u+ITOJptKsYxc3F3EVP36zaLbdHdAmArnGoe9kZO3AxNN3dR7ttfPk16KUeaQkaxA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-autoformat": "*",
+        "@types/ckeditor__ckeditor5-basic-styles": "*",
+        "@types/ckeditor__ckeditor5-block-quote": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-easy-image": "*",
+        "@types/ckeditor__ckeditor5-editor-inline": "*",
+        "@types/ckeditor__ckeditor5-essentials": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-list": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*",
+        "@types/ckeditor__ckeditor5-paste-from-office": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-ckfinder": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-ckfinder/-/ckeditor__ckeditor5-ckfinder-29.0.3.tgz",
+      "integrity": "sha512-RQVFIg/RrJzaA19FHD9Qzzl36sVUyyqY9ozWhEUWAmlKMUZW0MQBBtMN3vX5dZ81JtOaPVcwklNAa2yw6dqlkg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-ui": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-clipboard": {
+      "version": "29.0.5",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-clipboard/-/ckeditor__ckeditor5-clipboard-29.0.5.tgz",
+      "integrity": "sha512-AN7iniYu2C417LRNuOBIirBokStvPwXm/NG72o9Ivfn0/i7J0VZiJ8KGp7Wmvrcg/bhFYfZsTbEOVW2c/59Rjg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-cloud-services": {
+      "version": "29.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-cloud-services/-/ckeditor__ckeditor5-cloud-services-29.0.4.tgz",
+      "integrity": "sha512-fZOj+HBQbGFJg3SwUYqfdIQtFNnG2U2OCWkKDCIzUuejkdSeicF8P5GLSyNuDP0nTDdQMBqEWgzljqLZkJnkHg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-code-block": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-code-block/-/ckeditor__ckeditor5-code-block-29.0.3.tgz",
+      "integrity": "sha512-x3D3B8I21za6VShc3twNRzKBN4+1+pOrsXhb+TPgQLG2Q9oeRgPXhaHMhdXGAGebMWhdFlPs0lTNsQTCVjXm6A==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-collaboration-core": {
+      "version": "27.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-collaboration-core/-/ckeditor__ckeditor5-collaboration-core-27.1.2.tgz",
+      "integrity": "sha512-g0AKoJw820i/Biho6S9qYH1SaedjXr2P/gmnqO3k8/6HWiIMALaGDUkMgYvQC5nr+ZXIzLtv04Y0eb/9H1W3DQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-core": {
+      "version": "33.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-core/-/ckeditor__ckeditor5-core-33.0.3.tgz",
+      "integrity": "sha512-mVaU5+faOZ/2eR2jZb26H0JLqHLV/4a/p1/t7K9l8j5fMWTcubE5FRifjCk/TowazNW+/xcgRinyFnnUtNFUTQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-alignment": "*",
+        "@types/ckeditor__ckeditor5-autosave": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-code-block": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-export-pdf": "*",
+        "@types/ckeditor__ckeditor5-export-word": "*",
+        "@types/ckeditor__ckeditor5-font": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-highlight": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-language": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-mention": "*",
+        "@types/ckeditor__ckeditor5-minimap": "*",
+        "@types/ckeditor__ckeditor5-pagination": "*",
+        "@types/ckeditor__ckeditor5-real-time-collaboration": "*",
+        "@types/ckeditor__ckeditor5-restricted-editing": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-track-changes": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-upload": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-word-count": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-easy-image": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-easy-image/-/ckeditor__ckeditor5-easy-image-29.0.2.tgz",
+      "integrity": "sha512-pyBp+c0u1YydwAlWBubKzQrVkYmSApOjLmoc+F1yy/VuLelUhklaKnDlXo8HOjRXAndPHax0Yr966CWM7pQlpA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-upload": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-editor-balloon": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-editor-balloon/-/ckeditor__ckeditor5-editor-balloon-28.0.1.tgz",
+      "integrity": "sha512-fgzUNwp5IJaWC4NWVGiOFf4RP4fsaiTOdbAiaCKW7tk7oGUpzKMUQO/Y5GD62rUtwaeEpSKckd+Ke+Hx8WcQmg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-editor-classic": {
+      "version": "27.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-editor-classic/-/ckeditor__ckeditor5-editor-classic-27.1.2.tgz",
+      "integrity": "sha512-Xrxav0Bq+rxr/H//nK4+n9o0GpHHMJpfe96wAm4EbjTI5mbBQYH5mCZmKdU8JzQTq6DUF8w9D92RIShqx0rvLw==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-editor-inline": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-editor-inline/-/ckeditor__ckeditor5-editor-inline-28.0.3.tgz",
+      "integrity": "sha512-GuUAs+PZP8rOJNStp0BJ/Zng+w5HbsbVzPqOFjblgoDZWjUlBQ/DLpPnS5AfY5DdGcyyzfw3PMpo7HYJGL/XAg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-engine": {
+      "version": "32.0.11",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-engine/-/ckeditor__ckeditor5-engine-32.0.11.tgz",
+      "integrity": "sha512-mjP5DE+VvVdUqgn9SL1qTr5HRouG6xj+hiFu4Hzz3HWLLBaCEfK6dPUTc6/QM/nMNlNl8Ux9551qCYMoKanzvw==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-enter": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-enter/-/ckeditor__ckeditor5-enter-27.0.3.tgz",
+      "integrity": "sha512-qFv9QXk/kXkHQaS748FnO+XZoLOp34x25hOWpOFgBGbrfSZxJ6rYE+vk6BbX+b7sakj7glMctYeitNfGRMcVDQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-essentials": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-essentials/-/ckeditor__ckeditor5-essentials-28.0.3.tgz",
+      "integrity": "sha512-vHtxf97CSVTRMGpxsEfDduRASHL32+9rvr1bVTmLlTgdykMiP0HY+TmFt07XtDTCpwAShehLu4bc8Qg4mkCCCA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-select-all": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-undo": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-export-pdf": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-export-pdf/-/ckeditor__ckeditor5-export-pdf-31.0.0.tgz",
+      "integrity": "sha512-ZQdL2eI/zpPtmMB8Qd5VHqvDx8VNsnCs4SPMWgSG1lrwC7tM0cnyLkCcVxHQYcvZIlihzEF/QJJ+AV9waxT9Pg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-export-word": {
+      "version": "27.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-export-word/-/ckeditor__ckeditor5-export-word-27.0.4.tgz",
+      "integrity": "sha512-2cpRFCsTHUh3xlbr3IdqfxhRs2AnfvViT0qekhk3SnP9VsUBiqN9CPcgGkBvk3huv30w5kiIpT2UH8l1Ff5Biw==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-font": {
+      "version": "33.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-font/-/ckeditor__ckeditor5-font-33.0.1.tgz",
+      "integrity": "sha512-Hllu+akGhKWRtdahWqkewbmRV4DwPxuXjYzjlvqKoPMNst6UcBOYxeLR/HKoIqI4bn4Vc/p7mZvzKJs0R7CNGw==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-heading": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-heading/-/ckeditor__ckeditor5-heading-29.0.3.tgz",
+      "integrity": "sha512-GfitzATatW4/ZJZ10VFI2OU1nG+r+c7JDHC/s/+9NzkqAyOEd8XTScAX0Sape+vqoNvnMUSAHNa03/ktAjDIqQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-highlight": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-highlight/-/ckeditor__ckeditor5-highlight-29.0.3.tgz",
+      "integrity": "sha512-Akq45EwzdI/egK/5YpKkoyYkEvq0w1EaBZMNOaKn8HaNFmhI2mQPwNzGHfEjbGDpKalI9cNTo0ImvqcqNgF+hg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-image": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-image/-/ckeditor__ckeditor5-image-33.0.0.tgz",
+      "integrity": "sha512-rEu93lPml8CuG8UesJa3BBH6Bi84eskeHXgH5kXCPi+lGQvhHd3VrNWa6XgihnO4Z/60i4IYhW48vdWZJ/Iv/A==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-undo": "*",
+        "@types/ckeditor__ckeditor5-upload": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-indent": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-indent/-/ckeditor__ckeditor5-indent-29.0.3.tgz",
+      "integrity": "sha512-ijVRz3hVR+KT4AmaHxOIyFd/Wi+XLtf5zDQuHP1DMAYgwudj6VGTfFl4vpebFB5wrWeY8EzkJZO1KsRlI21QdA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-language": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-language/-/ckeditor__ckeditor5-language-32.0.0.tgz",
+      "integrity": "sha512-8vd0nRXXZgV5oUF0g6DdBfwWAj3KlQGjpMgxgp6cXBQJ86fINCyyGpqpSmd5L4iSrJHAN3OfQaKLlh9PHLcCVQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-link": {
+      "version": "32.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-link/-/ckeditor__ckeditor5-link-32.0.4.tgz",
+      "integrity": "sha512-ElABiBSynJvNpJ6kFSrOKfhtmVYUv7i158akP5VBnvI744hmvM3vl8D3Jjfj+/xKBFkHpJG9YN9XA0BSr+sOqA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-list": {
+      "version": "32.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-list/-/ckeditor__ckeditor5-list-32.0.1.tgz",
+      "integrity": "sha512-FJxpxq56CgyRhI3DAaxWuKFHQH2ZZPFyKgj/3kF3qMbS2YJ2bBhh9/IfnMi1R2Gesdm0aNgCzM/Q+xp3j4ftHQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-media-embed": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-media-embed/-/ckeditor__ckeditor5-media-embed-29.0.3.tgz",
+      "integrity": "sha512-Z1EAZ/s04KTh+MJHZ2Xj2ugwX8lOBmlga7BWdzO4/HkJVeNzozWjp4Kxj9bxVr3GA+EaGWS6MHqgnhtN4gqhfg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-undo": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-mention": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-mention/-/ckeditor__ckeditor5-mention-31.0.0.tgz",
+      "integrity": "sha512-V2Xq+OrpegeKK6lWaJkpKLZNgW/nLZPhRl6p1rirKsEyVpxxjFO3qSZr3Byb7lxeRkyVLgR23hVgcvt8vfb5AQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-minimap": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-minimap/-/ckeditor__ckeditor5-minimap-33.0.0.tgz",
+      "integrity": "sha512-XLu/QyyWVMzQseSqo/hQDWoBKzpZS83pXUwUmJcnXoK+lxaxuh8hYxY8W9qY5vrhh2IHocyrNnjMsLJLtu9FTA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-pagination": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-pagination/-/ckeditor__ckeditor5-pagination-27.0.3.tgz",
+      "integrity": "sha512-2kyuvQyyi30aZbZHCh0wGpSVp9Q+v5N5AvEHAuSvj6/GOmPRdxK4YyAK/aO3FapUb3bxgvQilyIdA6JtIx1inQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-paragraph": {
+      "version": "27.0.5",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-paragraph/-/ckeditor__ckeditor5-paragraph-27.0.5.tgz",
+      "integrity": "sha512-Clevh7N4G15uFZky505TIM+9qYh9Qwf1oULyh9ntsCxDUNMpqhbmRjC/9J+qcTNLLZ1xppEs75r3ejM01ZkcQg==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-paste-from-office": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-paste-from-office/-/ckeditor__ckeditor5-paste-from-office-29.0.1.tgz",
+      "integrity": "sha512-/Asiwf6/cIA1R0tLIpsdiwyqOKYGQLc9va/GdTeZSAj1YG5OENeMlUK32pRth5BxS7dFlhK/xDsP5NhY/ZEUvQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-real-time-collaboration": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-real-time-collaboration/-/ckeditor__ckeditor5-real-time-collaboration-32.0.0.tgz",
+      "integrity": "sha512-u93DiYz2Q2+0ILR4srrmabWYlBx1LTcEusSbE7ylvQrcTs4qmgWlio81FyEMEtn9G5hG4kqH/WN0WfhHjWoFTQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-collaboration-core": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-restricted-editing": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-restricted-editing/-/ckeditor__ckeditor5-restricted-editing-32.0.0.tgz",
+      "integrity": "sha512-FCOqLUbMxHBaghkXuVHl6hJy9VmimlEXPiMSHeK1jmjq3prsCvavup31Ps+zhwPlo0Bd7aS7GBdUJPGuYkYP9w==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-select-all": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-select-all/-/ckeditor__ckeditor5-select-all-31.0.0.tgz",
+      "integrity": "sha512-Sgp9N7HHdRcE+9UZlamI3f3ZUCt1fbAYyBv3OhmS9RO9Ev/vejGcSCh3tEddzLfqBcU9HNnl39SQK0zCjeKLEA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-table": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-table/-/ckeditor__ckeditor5-table-33.0.0.tgz",
+      "integrity": "sha512-a711hMOd4u/zqP/dTvEoP/bpnKLxfRasaZtiv3kepIAYub2Acz5ZOi9Gha71sWRwGK3Jeq+4q8gPuNJHYSRttQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-track-changes": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-track-changes/-/ckeditor__ckeditor5-track-changes-32.0.0.tgz",
+      "integrity": "sha512-fFe+Tnni2BzrnOYD46zSkAf/StCSAaClN+lILHlWGBKo1xMod1T+hcsrnPkVrFwYSlXraDIvJIEeArrXYCKGnA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-collaboration-core": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-typing": {
+      "version": "32.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-typing/-/ckeditor__ckeditor5-typing-32.0.1.tgz",
+      "integrity": "sha512-DskFBdfcUACpxVjhdpZTCD8H3gnG/zu08kWyT6TczuBJEXTRoCfX/lZ0Dh7sd20/dxow21pLC4V9Uv/yNUquBA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-ui": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-ui/-/ckeditor__ckeditor5-ui-32.0.2.tgz",
+      "integrity": "sha512-0cAaEtXB+i8jnSQMVB50LqI91gJkmG8AnFsowpRPJczsnakMNYTlV+cEhPMe2RbwWxScler0jLmUNsbEORZOTw==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-undo": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-undo/-/ckeditor__ckeditor5-undo-27.0.3.tgz",
+      "integrity": "sha512-UpbmO0V82XvoVsnIjdM1Cb9RE9lB9vxGYKkQUzGwtw4wZbMb1A+CMIYkZIXO3aNs6x42F562ymFpjjkHBzgLHA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-upload": {
+      "version": "27.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-upload/-/ckeditor__ckeditor5-upload-27.0.7.tgz",
+      "integrity": "sha512-E8ubVL/94RX4qQe5M7OmSEmH1sTRfz0cwSmfe/vRlTedzM5pzwczXXMYzbnbz28UzOmraOS0Zgq+9WVBcPHJ6Q==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-utils": {
+      "version": "28.0.14",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-utils/-/ckeditor__ckeditor5-utils-28.0.14.tgz",
+      "integrity": "sha512-EJmGXoBOAxSwQIWdj3EEx4f7LWLkAP5P5RNYnWEUwBO3e3MdtLt/f8mTRyx1bnt1dmdrrAKD9hVJx1216vXOnQ==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-widget": {
+      "version": "33.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-widget/-/ckeditor__ckeditor5-widget-33.0.1.tgz",
+      "integrity": "sha512-dHhFdVj2LFo0nCYJOYB5hohZiJNrkI0xICBBejbnzHxzyjxgYpaUoOKsItjxl49DeCdEJ82DU9Wu/cpmTJyCKw==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "node_modules/@types/ckeditor__ckeditor5-word-count": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-word-count/-/ckeditor__ckeditor5-word-count-29.0.2.tgz",
+      "integrity": "sha512-eZ9NwCtTsWOLtNYxLfNvBLx6DfcPgYh4+2p9508zQbQ4x9jMOgs9Vx4tGbFVM501eIGCp4g1XjobbWGuBJqpMA==",
+      "dependencies": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
     },
     "node_modules/@types/codemirror": {
       "version": "0.0.106",
@@ -2242,6 +3294,30 @@
       "resolved": "https://registry.npmjs.org/ckeditor/-/ckeditor-4.12.1.tgz",
       "integrity": "sha512-pH2Su4oi0D4iN/3U8nUcwI7/lXHoOJi0aiN8e2zxnm4Ow5kq8eZP2ZGmpYyuqRyKZ2tHaU8+OyYi7laXcjiq9Q==",
       "dev": true
+    },
+    "node_modules/ckeditor5": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-35.0.1.tgz",
+      "integrity": "sha512-bJbD06JJAObH5vnCGQsmWkwgGKZluX0rILaZ47E/TBFLuUgEce0yTsmgGBcQUf0OQZ4IwoXt7vv+Y6zO1Ad86Q==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "^35.0.1",
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-enter": "^35.0.1",
+        "@ckeditor/ckeditor5-paragraph": "^35.0.1",
+        "@ckeditor/ckeditor5-select-all": "^35.0.1",
+        "@ckeditor/ckeditor5-typing": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-undo": "^35.0.1",
+        "@ckeditor/ckeditor5-upload": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "@ckeditor/ckeditor5-widget": "^35.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=5.7.1"
+      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -5790,6 +6866,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -9802,6 +10884,341 @@
         }
       }
     },
+    "@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-35.0.1.tgz",
+      "integrity": "sha512-TASf7EnSw0ndTwTGWUBsFz9lZpQvXeEv/8icGwwBOlDe5arj/v4Xk9kqyWysXi6Mv/PTEpVEXV8xrAPX7oHpbg==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-autoformat": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-35.0.1.tgz",
+      "integrity": "sha512-Q/dWKR3IASmlSRC7GY14hWJ6t1alKG5+9gPvGfF2qQhvKYkGdUEdvhiUs2xcvRuIOzR4nszYvy9Kj9j+NReBRQ==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-basic-styles": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-35.0.1.tgz",
+      "integrity": "sha512-Srg5Kbb5Gux+xTu24Wp+R/NbFUTM36bU/hgxSzfERvQgeDAp7TMdf2O/BCLrm6aTVHowgnUOFsH5PgnuG+rxsQ==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-block-quote": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-35.0.1.tgz",
+      "integrity": "sha512-s4ef9M/1SHAT2e0nK3AHSWmN8CpK5VUfYBa5hXey8QycTaLVxAbOs+jxki6+KJHlozikJ+BxXNj03CWROrR/Tw==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-build-inline": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-inline/-/ckeditor5-build-inline-35.0.1.tgz",
+      "integrity": "sha512-ellVKLUNaCrTMuleWwRB64GG8lM4Mc4TGpyfSrc8nvuuaBnzkSBD+ybLqIBaYl4d1lfGPo7glF+gURfqcLEiNg==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "^35.0.1",
+        "@ckeditor/ckeditor5-autoformat": "^35.0.1",
+        "@ckeditor/ckeditor5-basic-styles": "^35.0.1",
+        "@ckeditor/ckeditor5-block-quote": "^35.0.1",
+        "@ckeditor/ckeditor5-ckbox": "^35.0.1",
+        "@ckeditor/ckeditor5-ckfinder": "^35.0.1",
+        "@ckeditor/ckeditor5-cloud-services": "^35.0.1",
+        "@ckeditor/ckeditor5-easy-image": "^35.0.1",
+        "@ckeditor/ckeditor5-editor-inline": "^35.0.1",
+        "@ckeditor/ckeditor5-essentials": "^35.0.1",
+        "@ckeditor/ckeditor5-heading": "^35.0.1",
+        "@ckeditor/ckeditor5-image": "^35.0.1",
+        "@ckeditor/ckeditor5-indent": "^35.0.1",
+        "@ckeditor/ckeditor5-link": "^35.0.1",
+        "@ckeditor/ckeditor5-list": "^35.0.1",
+        "@ckeditor/ckeditor5-media-embed": "^35.0.1",
+        "@ckeditor/ckeditor5-paragraph": "^35.0.1",
+        "@ckeditor/ckeditor5-paste-from-office": "^35.0.1",
+        "@ckeditor/ckeditor5-table": "^35.0.1",
+        "@ckeditor/ckeditor5-typing": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-ckbox": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-35.0.1.tgz",
+      "integrity": "sha512-E0lYBPBMsOjYqEtBVlx6H47dHnnz9fcS6DvvXKs1Je8OKQNcEf/N8akGoD1lOx6E9C5zTrCln7UdY2JcIQhy+w==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-ckfinder": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-35.0.1.tgz",
+      "integrity": "sha512-Cy+esbIxhWJvEpls+FqNLqukQ6RKbFhqJPOfno6K9ePITImSu5H0bAMYYFgdiIQVduMuJzlpOrbUCJiU13GKFg==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-clipboard": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-35.0.1.tgz",
+      "integrity": "sha512-XHBnR+v+GLXondSrJdpTLT3++0++Ja5gNC2zKdpDx6ykayQVYF0Nry+XoXbbzffnXYnRrWzo++r32ngW39rFUQ==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "@ckeditor/ckeditor5-widget": "^35.0.1",
+        "lodash-es": "^4.17.11"
+      }
+    },
+    "@ckeditor/ckeditor5-cloud-services": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-35.0.1.tgz",
+      "integrity": "sha512-/GXmhQ8/NHXv3V1Oh1MA/x9uKj1PrmC4CglE33mB9JfcL+y7gY0gRRjFykDXlijNhp5Ro1Av9OnHimXRHLYCUg==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-core": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-35.0.1.tgz",
+      "integrity": "sha512-yLX4WwyKjBbgINfl3wB8nyAtxclmP8FBVWunnHZ+YBq6KryB0uWcplP1Nomz/3uyask6k2YN/rSY0Lu9xJ9uyQ==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-easy-image": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-35.0.1.tgz",
+      "integrity": "sha512-KVxc5MTkn+iSRKm8aUEilqAvwQnPQrpSUpvi13bgVIt/ueGQ/uCOYQRSEaCZbs9HWfEv/f/Q+WZ5hB+ocW57vg==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-inline": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-35.0.1.tgz",
+      "integrity": "sha512-TvwG8RavE2+FkQtsuTMg8e1GdnHDC5m/YkIZEx5lo8ax71GoZP6ze9WipLYtvLmLD+yLnCCVp36/ZTkWcIsgCA==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-engine": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-35.0.1.tgz",
+      "integrity": "sha512-Jz1sEBnFr06a1ezOqTbydClp9GgK/YL1CyvilCYIOoRiMevr1XMR3slsJCXC8AmHAcDn+PtxSniw+CREFZaTAA==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-enter": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-35.0.1.tgz",
+      "integrity": "sha512-vNJzom2pSWyYrPk+VYjeSOBBeVI0B3P+DW1Vwyd3HfB1NKB7zU6T+7ByWwhvzdsv5xovzB+6X066lmUSV+W1fw==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-essentials": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-35.0.1.tgz",
+      "integrity": "sha512-uHfup2e2tETnuvJmHgey/JAYMdeK9eIe5VW2Ah4Q8Ndiu/Buajf+PFYWRFrnC8psaYyE3+vdHRwxV3SD/yZeKQ==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-heading": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-35.0.1.tgz",
+      "integrity": "sha512-Rfc/Pa1EBQZIDFrLlL5HXx1gO3x0ZBq8DfeRlZ4Z6mRlOIzxU6Wj74qWsG6wauVJ1/KVVsghUN4zJ3U26SDaPQ==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-image": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-35.0.1.tgz",
+      "integrity": "sha512-DQWe8b+wwBkoyXcV16EeZc1+FWoEXQo+/0N5lI5P0g7YYGTak9IGio+yPppyILOeW+U+nXQ3ZYIhOQo+T+3FnA==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-indent": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-35.0.1.tgz",
+      "integrity": "sha512-omD5EmhxAVLDRwSiq91NvNDkytF7RixyQrKOLH3XJ3W/ZtK++1fMBF5fyc0DdZdmTJX7B/8cA4paXfI8xNiEhg==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-link": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-35.0.1.tgz",
+      "integrity": "sha512-CJus1E3RvnkZ3VgEOsjYCvOePi/f+wlSZgRCrAD1IeUnjgzNMUMvAOO5QSeaR0CqqaBQcFoHRrVtCaBEIk21Yw==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-list": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-35.0.1.tgz",
+      "integrity": "sha512-8JaM+GILlTnJvKRJVcm+L7Wxo1lC179no6lfBV5Kyh+PRIWLiQi6gjX12AzRtFgn/tr/VKzfAKGaxf3etFPsFQ==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-media-embed": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-35.0.1.tgz",
+      "integrity": "sha512-SIypYAgSmRURy4OkOyrcHsaK5FObFt4bEmRUXIlIXcHZAyi1qxUnHic3RcS6a4D1RbFPbKLwb1hCf3rLqJdB6g==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-paragraph": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-35.0.1.tgz",
+      "integrity": "sha512-Ga+LWrXKDg6OXyPxBIaemgEfAKJlE40155IKsaeBHYZEVkS7eoDyuB5I3wFsmi8MRDrLwg6GDrBJ8bo/tKqmTg==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-paste-from-office": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-35.0.1.tgz",
+      "integrity": "sha512-Fib3mlaRdBTyItOkPsvYB+0jW6DzsOEQ3hDuaMmx1Fz0DYPRG/XRQKjLPJcFGXpzIs4EedYHCb9P2M0dLaL5Ww==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-select-all": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-35.0.1.tgz",
+      "integrity": "sha512-I7oPF3LjL7etN1sxtpTshu47BGz6CNYHlLWcvPtU5QB+xvildQU1c5HboReufooZpYb8N898Zi8tHcd4/ij/8w==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-table": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-35.0.1.tgz",
+      "integrity": "sha512-XKZHGn/MbLfxIqdaVKD62DfOBUKPV0MlKhfpc941LENOb2qhqvmixhdlde7vVi+0k1HzumRj1BQFUOVvncAEiA==",
+      "dev": true,
+      "requires": {
+        "ckeditor5": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-typing": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-35.0.1.tgz",
+      "integrity": "sha512-Yj3f8nv+iXsTxmnlTjFUk+Xcvd9OvtkFqsEgYdRA79TO71Gaigm2CLmi60wf39MtXc/hPCjhPSdvSk01CsNmQQ==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-ui": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-35.0.1.tgz",
+      "integrity": "sha512-JFmHShOQ7tGDFKqH93Ba2U5sZQMOts0ho1OveHeaKpyG3mbsonBofWr/JacF/dpoNBi1pj8I7ssYR4bFVTwO+w==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-undo": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-35.0.1.tgz",
+      "integrity": "sha512-zmO4JXCSd9JMikvjDGSvD3a2dAnlvTWMk2D8PSx5tNTj+MBm6pAbhqimeVdCQheBpAFQjH56ywKFZcYXJsXukA==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-upload": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-35.0.1.tgz",
+      "integrity": "sha512-h/a7KM/StexPhbwcdjoYz7pcU86QLhNUw9pNdogR4L4OXUeDd0c6V0YWqaqbMc3HtC+N2+5tePwiV4Aw0NalNg==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1"
+      }
+    },
+    "@ckeditor/ckeditor5-utils": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-35.0.1.tgz",
+      "integrity": "sha512-H0ec3f963FpLPuLb58p4RbzkgiOYYNk7goNF4XVROZ4Vjf2dcGLJCDhUSHRBwz3cRL/zZ8a/f7HX/PBpYmnWlw==",
+      "dev": true,
+      "requires": {
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-widget": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-35.0.1.tgz",
+      "integrity": "sha512-+XhPafSq/bRewa/cLddJGhon2lMsP9XuKsitSOogU0/LlyWNhyjcgUB2xPhGzfw5BO+CY1ptDBpgyw0lSxWOOw==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-enter": "^35.0.1",
+        "@ckeditor/ckeditor5-typing": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "lodash-es": "^4.17.15"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -9941,6 +11358,594 @@
       "version": "4.9.10",
       "resolved": "https://registry.npmjs.org/@types/ckeditor/-/ckeditor-4.9.10.tgz",
       "integrity": "sha512-dcOPCXM0Cr5Z0i6eF/aW5LvECrS+cdl2Gi7lU+rEUNWby0w9Yl6mBubjrs29OVAducpuZjB4mfDayE+o4/gGdQ=="
+    },
+    "@types/ckeditor__ckeditor5-adapter-ckfinder": {
+      "version": "29.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-adapter-ckfinder/-/ckeditor__ckeditor5-adapter-ckfinder-29.0.4.tgz",
+      "integrity": "sha512-baT+KeQG12qfu0iDu+TIy1BSM/OWzzvH8pTkSIckQhRwEt2mlW8jFNQMZGRi4kAmLabMoLvybiAn1yFDeepddw==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-upload": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-alignment": {
+      "version": "29.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-alignment/-/ckeditor__ckeditor5-alignment-29.0.7.tgz",
+      "integrity": "sha512-tZIF0svmHOHIvbnFM074b2CySBKKQxxZG5Y41UFAvkIYxel4LTZmFV3uTbdDTmniLRIbG219vOXtWHOJ5INB/A==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-autoformat": {
+      "version": "31.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-autoformat/-/ckeditor__ckeditor5-autoformat-31.0.1.tgz",
+      "integrity": "sha512-E2bDInIyq6J5slWDAruCRTCvWxCH1Gm91d70/V2+YKiwpzj0X0EXyIPTqO01xTbdjHbCy9XiGIZ7fVLDrzchNQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-autosave": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-autosave/-/ckeditor__ckeditor5-autosave-32.0.0.tgz",
+      "integrity": "sha512-auGeVgBG4HLXwPTbHQSsfGZcItntaBuBQN8LSreZea0ur4SJ6NKfh25USqIIQs1DUWYMDPiK6ODwSn2mhyfJ2A==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-basic-styles": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-basic-styles/-/ckeditor__ckeditor5-basic-styles-28.0.2.tgz",
+      "integrity": "sha512-ap6vMacs5rjcWRlHrYPsZPshHoPR7sruPgbuzduGQCy7X86SglOPwtd6XvMOMItslbLv1wYbJ3h9+S1kBOVvfA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-block-quote": {
+      "version": "29.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-block-quote/-/ckeditor__ckeditor5-block-quote-29.0.4.tgz",
+      "integrity": "sha512-FwNayTN7/8hdxCSA9cBiab4rEG3jERy+bF6qgr5pYwCiEthghlKT87IYqFYmVhznSsfqqR3KHi2a6GIfJMHpCA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-build-balloon": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-build-balloon/-/ckeditor__ckeditor5-build-balloon-29.1.1.tgz",
+      "integrity": "sha512-unvqLKPQ3ovQHNtCec0EbckUC432p5kC+8edcT99Fj2e2lCdQH9UBpi0RowH/p1VZ8Auflf2ebF1Vnu84Lr2UQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-autoformat": "*",
+        "@types/ckeditor__ckeditor5-basic-styles": "*",
+        "@types/ckeditor__ckeditor5-block-quote": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-easy-image": "*",
+        "@types/ckeditor__ckeditor5-editor-balloon": "*",
+        "@types/ckeditor__ckeditor5-essentials": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-list": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*",
+        "@types/ckeditor__ckeditor5-paste-from-office": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-build-classic": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-build-classic/-/ckeditor__ckeditor5-build-classic-29.0.1.tgz",
+      "integrity": "sha512-liWJN2v9xSJSLuU048nO7i7dr49T4REWhqSe7D7qcGcY3M5n7bVZnSNUnmBCB61WJg5iBl+KfwfdpDIDYp7+XQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-autoformat": "*",
+        "@types/ckeditor__ckeditor5-basic-styles": "*",
+        "@types/ckeditor__ckeditor5-block-quote": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-easy-image": "*",
+        "@types/ckeditor__ckeditor5-editor-classic": "*",
+        "@types/ckeditor__ckeditor5-essentials": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-list": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*",
+        "@types/ckeditor__ckeditor5-paste-from-office": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-build-inline": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-build-inline/-/ckeditor__ckeditor5-build-inline-29.0.0.tgz",
+      "integrity": "sha512-kWQlKmGuo7MVjwyIAXrf4u+ITOJptKsYxc3F3EVP36zaLbdHdAmArnGoe9kZO3AxNN3dR7ttfPk16KUeaQkaxA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-autoformat": "*",
+        "@types/ckeditor__ckeditor5-basic-styles": "*",
+        "@types/ckeditor__ckeditor5-block-quote": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-easy-image": "*",
+        "@types/ckeditor__ckeditor5-editor-inline": "*",
+        "@types/ckeditor__ckeditor5-essentials": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-list": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*",
+        "@types/ckeditor__ckeditor5-paste-from-office": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-typing": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-ckfinder": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-ckfinder/-/ckeditor__ckeditor5-ckfinder-29.0.3.tgz",
+      "integrity": "sha512-RQVFIg/RrJzaA19FHD9Qzzl36sVUyyqY9ozWhEUWAmlKMUZW0MQBBtMN3vX5dZ81JtOaPVcwklNAa2yw6dqlkg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-adapter-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-ui": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-clipboard": {
+      "version": "29.0.5",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-clipboard/-/ckeditor__ckeditor5-clipboard-29.0.5.tgz",
+      "integrity": "sha512-AN7iniYu2C417LRNuOBIirBokStvPwXm/NG72o9Ivfn0/i7J0VZiJ8KGp7Wmvrcg/bhFYfZsTbEOVW2c/59Rjg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-cloud-services": {
+      "version": "29.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-cloud-services/-/ckeditor__ckeditor5-cloud-services-29.0.4.tgz",
+      "integrity": "sha512-fZOj+HBQbGFJg3SwUYqfdIQtFNnG2U2OCWkKDCIzUuejkdSeicF8P5GLSyNuDP0nTDdQMBqEWgzljqLZkJnkHg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-code-block": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-code-block/-/ckeditor__ckeditor5-code-block-29.0.3.tgz",
+      "integrity": "sha512-x3D3B8I21za6VShc3twNRzKBN4+1+pOrsXhb+TPgQLG2Q9oeRgPXhaHMhdXGAGebMWhdFlPs0lTNsQTCVjXm6A==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-collaboration-core": {
+      "version": "27.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-collaboration-core/-/ckeditor__ckeditor5-collaboration-core-27.1.2.tgz",
+      "integrity": "sha512-g0AKoJw820i/Biho6S9qYH1SaedjXr2P/gmnqO3k8/6HWiIMALaGDUkMgYvQC5nr+ZXIzLtv04Y0eb/9H1W3DQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-core": {
+      "version": "33.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-core/-/ckeditor__ckeditor5-core-33.0.3.tgz",
+      "integrity": "sha512-mVaU5+faOZ/2eR2jZb26H0JLqHLV/4a/p1/t7K9l8j5fMWTcubE5FRifjCk/TowazNW+/xcgRinyFnnUtNFUTQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-alignment": "*",
+        "@types/ckeditor__ckeditor5-autosave": "*",
+        "@types/ckeditor__ckeditor5-ckfinder": "*",
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-code-block": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-export-pdf": "*",
+        "@types/ckeditor__ckeditor5-export-word": "*",
+        "@types/ckeditor__ckeditor5-font": "*",
+        "@types/ckeditor__ckeditor5-heading": "*",
+        "@types/ckeditor__ckeditor5-highlight": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-indent": "*",
+        "@types/ckeditor__ckeditor5-language": "*",
+        "@types/ckeditor__ckeditor5-link": "*",
+        "@types/ckeditor__ckeditor5-media-embed": "*",
+        "@types/ckeditor__ckeditor5-mention": "*",
+        "@types/ckeditor__ckeditor5-minimap": "*",
+        "@types/ckeditor__ckeditor5-pagination": "*",
+        "@types/ckeditor__ckeditor5-real-time-collaboration": "*",
+        "@types/ckeditor__ckeditor5-restricted-editing": "*",
+        "@types/ckeditor__ckeditor5-table": "*",
+        "@types/ckeditor__ckeditor5-track-changes": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-upload": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-word-count": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-easy-image": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-easy-image/-/ckeditor__ckeditor5-easy-image-29.0.2.tgz",
+      "integrity": "sha512-pyBp+c0u1YydwAlWBubKzQrVkYmSApOjLmoc+F1yy/VuLelUhklaKnDlXo8HOjRXAndPHax0Yr966CWM7pQlpA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-cloud-services": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-upload": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-editor-balloon": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-editor-balloon/-/ckeditor__ckeditor5-editor-balloon-28.0.1.tgz",
+      "integrity": "sha512-fgzUNwp5IJaWC4NWVGiOFf4RP4fsaiTOdbAiaCKW7tk7oGUpzKMUQO/Y5GD62rUtwaeEpSKckd+Ke+Hx8WcQmg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-editor-classic": {
+      "version": "27.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-editor-classic/-/ckeditor__ckeditor5-editor-classic-27.1.2.tgz",
+      "integrity": "sha512-Xrxav0Bq+rxr/H//nK4+n9o0GpHHMJpfe96wAm4EbjTI5mbBQYH5mCZmKdU8JzQTq6DUF8w9D92RIShqx0rvLw==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-editor-inline": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-editor-inline/-/ckeditor__ckeditor5-editor-inline-28.0.3.tgz",
+      "integrity": "sha512-GuUAs+PZP8rOJNStp0BJ/Zng+w5HbsbVzPqOFjblgoDZWjUlBQ/DLpPnS5AfY5DdGcyyzfw3PMpo7HYJGL/XAg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-engine": {
+      "version": "32.0.11",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-engine/-/ckeditor__ckeditor5-engine-32.0.11.tgz",
+      "integrity": "sha512-mjP5DE+VvVdUqgn9SL1qTr5HRouG6xj+hiFu4Hzz3HWLLBaCEfK6dPUTc6/QM/nMNlNl8Ux9551qCYMoKanzvw==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-enter": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-enter/-/ckeditor__ckeditor5-enter-27.0.3.tgz",
+      "integrity": "sha512-qFv9QXk/kXkHQaS748FnO+XZoLOp34x25hOWpOFgBGbrfSZxJ6rYE+vk6BbX+b7sakj7glMctYeitNfGRMcVDQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-essentials": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-essentials/-/ckeditor__ckeditor5-essentials-28.0.3.tgz",
+      "integrity": "sha512-vHtxf97CSVTRMGpxsEfDduRASHL32+9rvr1bVTmLlTgdykMiP0HY+TmFt07XtDTCpwAShehLu4bc8Qg4mkCCCA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-select-all": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-undo": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-export-pdf": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-export-pdf/-/ckeditor__ckeditor5-export-pdf-31.0.0.tgz",
+      "integrity": "sha512-ZQdL2eI/zpPtmMB8Qd5VHqvDx8VNsnCs4SPMWgSG1lrwC7tM0cnyLkCcVxHQYcvZIlihzEF/QJJ+AV9waxT9Pg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-export-word": {
+      "version": "27.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-export-word/-/ckeditor__ckeditor5-export-word-27.0.4.tgz",
+      "integrity": "sha512-2cpRFCsTHUh3xlbr3IdqfxhRs2AnfvViT0qekhk3SnP9VsUBiqN9CPcgGkBvk3huv30w5kiIpT2UH8l1Ff5Biw==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-font": {
+      "version": "33.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-font/-/ckeditor__ckeditor5-font-33.0.1.tgz",
+      "integrity": "sha512-Hllu+akGhKWRtdahWqkewbmRV4DwPxuXjYzjlvqKoPMNst6UcBOYxeLR/HKoIqI4bn4Vc/p7mZvzKJs0R7CNGw==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-heading": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-heading/-/ckeditor__ckeditor5-heading-29.0.3.tgz",
+      "integrity": "sha512-GfitzATatW4/ZJZ10VFI2OU1nG+r+c7JDHC/s/+9NzkqAyOEd8XTScAX0Sape+vqoNvnMUSAHNa03/ktAjDIqQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-paragraph": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-highlight": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-highlight/-/ckeditor__ckeditor5-highlight-29.0.3.tgz",
+      "integrity": "sha512-Akq45EwzdI/egK/5YpKkoyYkEvq0w1EaBZMNOaKn8HaNFmhI2mQPwNzGHfEjbGDpKalI9cNTo0ImvqcqNgF+hg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-image": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-image/-/ckeditor__ckeditor5-image-33.0.0.tgz",
+      "integrity": "sha512-rEu93lPml8CuG8UesJa3BBH6Bi84eskeHXgH5kXCPi+lGQvhHd3VrNWa6XgihnO4Z/60i4IYhW48vdWZJ/Iv/A==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-undo": "*",
+        "@types/ckeditor__ckeditor5-upload": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-indent": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-indent/-/ckeditor__ckeditor5-indent-29.0.3.tgz",
+      "integrity": "sha512-ijVRz3hVR+KT4AmaHxOIyFd/Wi+XLtf5zDQuHP1DMAYgwudj6VGTfFl4vpebFB5wrWeY8EzkJZO1KsRlI21QdA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-language": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-language/-/ckeditor__ckeditor5-language-32.0.0.tgz",
+      "integrity": "sha512-8vd0nRXXZgV5oUF0g6DdBfwWAj3KlQGjpMgxgp6cXBQJ86fINCyyGpqpSmd5L4iSrJHAN3OfQaKLlh9PHLcCVQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-link": {
+      "version": "32.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-link/-/ckeditor__ckeditor5-link-32.0.4.tgz",
+      "integrity": "sha512-ElABiBSynJvNpJ6kFSrOKfhtmVYUv7i158akP5VBnvI744hmvM3vl8D3Jjfj+/xKBFkHpJG9YN9XA0BSr+sOqA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-image": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-list": {
+      "version": "32.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-list/-/ckeditor__ckeditor5-list-32.0.1.tgz",
+      "integrity": "sha512-FJxpxq56CgyRhI3DAaxWuKFHQH2ZZPFyKgj/3kF3qMbS2YJ2bBhh9/IfnMi1R2Gesdm0aNgCzM/Q+xp3j4ftHQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-media-embed": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-media-embed/-/ckeditor__ckeditor5-media-embed-29.0.3.tgz",
+      "integrity": "sha512-Z1EAZ/s04KTh+MJHZ2Xj2ugwX8lOBmlga7BWdzO4/HkJVeNzozWjp4Kxj9bxVr3GA+EaGWS6MHqgnhtN4gqhfg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-undo": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-mention": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-mention/-/ckeditor__ckeditor5-mention-31.0.0.tgz",
+      "integrity": "sha512-V2Xq+OrpegeKK6lWaJkpKLZNgW/nLZPhRl6p1rirKsEyVpxxjFO3qSZr3Byb7lxeRkyVLgR23hVgcvt8vfb5AQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-minimap": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-minimap/-/ckeditor__ckeditor5-minimap-33.0.0.tgz",
+      "integrity": "sha512-XLu/QyyWVMzQseSqo/hQDWoBKzpZS83pXUwUmJcnXoK+lxaxuh8hYxY8W9qY5vrhh2IHocyrNnjMsLJLtu9FTA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-pagination": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-pagination/-/ckeditor__ckeditor5-pagination-27.0.3.tgz",
+      "integrity": "sha512-2kyuvQyyi30aZbZHCh0wGpSVp9Q+v5N5AvEHAuSvj6/GOmPRdxK4YyAK/aO3FapUb3bxgvQilyIdA6JtIx1inQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-paragraph": {
+      "version": "27.0.5",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-paragraph/-/ckeditor__ckeditor5-paragraph-27.0.5.tgz",
+      "integrity": "sha512-Clevh7N4G15uFZky505TIM+9qYh9Qwf1oULyh9ntsCxDUNMpqhbmRjC/9J+qcTNLLZ1xppEs75r3ejM01ZkcQg==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-paste-from-office": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-paste-from-office/-/ckeditor__ckeditor5-paste-from-office-29.0.1.tgz",
+      "integrity": "sha512-/Asiwf6/cIA1R0tLIpsdiwyqOKYGQLc9va/GdTeZSAj1YG5OENeMlUK32pRth5BxS7dFlhK/xDsP5NhY/ZEUvQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-clipboard": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-real-time-collaboration": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-real-time-collaboration/-/ckeditor__ckeditor5-real-time-collaboration-32.0.0.tgz",
+      "integrity": "sha512-u93DiYz2Q2+0ILR4srrmabWYlBx1LTcEusSbE7ylvQrcTs4qmgWlio81FyEMEtn9G5hG4kqH/WN0WfhHjWoFTQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-collaboration-core": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-restricted-editing": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-restricted-editing/-/ckeditor__ckeditor5-restricted-editing-32.0.0.tgz",
+      "integrity": "sha512-FCOqLUbMxHBaghkXuVHl6hJy9VmimlEXPiMSHeK1jmjq3prsCvavup31Ps+zhwPlo0Bd7aS7GBdUJPGuYkYP9w==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-select-all": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-select-all/-/ckeditor__ckeditor5-select-all-31.0.0.tgz",
+      "integrity": "sha512-Sgp9N7HHdRcE+9UZlamI3f3ZUCt1fbAYyBv3OhmS9RO9Ev/vejGcSCh3tEddzLfqBcU9HNnl39SQK0zCjeKLEA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-table": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-table/-/ckeditor__ckeditor5-table-33.0.0.tgz",
+      "integrity": "sha512-a711hMOd4u/zqP/dTvEoP/bpnKLxfRasaZtiv3kepIAYub2Acz5ZOi9Gha71sWRwGK3Jeq+4q8gPuNJHYSRttQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*",
+        "@types/ckeditor__ckeditor5-widget": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-track-changes": {
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-track-changes/-/ckeditor__ckeditor5-track-changes-32.0.0.tgz",
+      "integrity": "sha512-fFe+Tnni2BzrnOYD46zSkAf/StCSAaClN+lILHlWGBKo1xMod1T+hcsrnPkVrFwYSlXraDIvJIEeArrXYCKGnA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-collaboration-core": "*",
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-typing": {
+      "version": "32.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-typing/-/ckeditor__ckeditor5-typing-32.0.1.tgz",
+      "integrity": "sha512-DskFBdfcUACpxVjhdpZTCD8H3gnG/zu08kWyT6TczuBJEXTRoCfX/lZ0Dh7sd20/dxow21pLC4V9Uv/yNUquBA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-ui": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-ui/-/ckeditor__ckeditor5-ui-32.0.2.tgz",
+      "integrity": "sha512-0cAaEtXB+i8jnSQMVB50LqI91gJkmG8AnFsowpRPJczsnakMNYTlV+cEhPMe2RbwWxScler0jLmUNsbEORZOTw==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-undo": {
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-undo/-/ckeditor__ckeditor5-undo-27.0.3.tgz",
+      "integrity": "sha512-UpbmO0V82XvoVsnIjdM1Cb9RE9lB9vxGYKkQUzGwtw4wZbMb1A+CMIYkZIXO3aNs6x42F562ymFpjjkHBzgLHA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-upload": {
+      "version": "27.0.7",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-upload/-/ckeditor__ckeditor5-upload-27.0.7.tgz",
+      "integrity": "sha512-E8ubVL/94RX4qQe5M7OmSEmH1sTRfz0cwSmfe/vRlTedzM5pzwczXXMYzbnbz28UzOmraOS0Zgq+9WVBcPHJ6Q==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-utils": {
+      "version": "28.0.14",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-utils/-/ckeditor__ckeditor5-utils-28.0.14.tgz",
+      "integrity": "sha512-EJmGXoBOAxSwQIWdj3EEx4f7LWLkAP5P5RNYnWEUwBO3e3MdtLt/f8mTRyx1bnt1dmdrrAKD9hVJx1216vXOnQ==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-widget": {
+      "version": "33.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-widget/-/ckeditor__ckeditor5-widget-33.0.1.tgz",
+      "integrity": "sha512-dHhFdVj2LFo0nCYJOYB5hohZiJNrkI0xICBBejbnzHxzyjxgYpaUoOKsItjxl49DeCdEJ82DU9Wu/cpmTJyCKw==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*",
+        "@types/ckeditor__ckeditor5-enter": "*",
+        "@types/ckeditor__ckeditor5-typing": "*",
+        "@types/ckeditor__ckeditor5-ui": "*",
+        "@types/ckeditor__ckeditor5-utils": "*"
+      }
+    },
+    "@types/ckeditor__ckeditor5-word-count": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor__ckeditor5-word-count/-/ckeditor__ckeditor5-word-count-29.0.2.tgz",
+      "integrity": "sha512-eZ9NwCtTsWOLtNYxLfNvBLx6DfcPgYh4+2p9508zQbQ4x9jMOgs9Vx4tGbFVM501eIGCp4g1XjobbWGuBJqpMA==",
+      "requires": {
+        "@types/ckeditor__ckeditor5-core": "*",
+        "@types/ckeditor__ckeditor5-engine": "*"
+      }
     },
     "@types/codemirror": {
       "version": "0.0.106",
@@ -11385,6 +13390,26 @@
       "resolved": "https://registry.npmjs.org/ckeditor/-/ckeditor-4.12.1.tgz",
       "integrity": "sha512-pH2Su4oi0D4iN/3U8nUcwI7/lXHoOJi0aiN8e2zxnm4Ow5kq8eZP2ZGmpYyuqRyKZ2tHaU8+OyYi7laXcjiq9Q==",
       "dev": true
+    },
+    "ckeditor5": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-35.0.1.tgz",
+      "integrity": "sha512-bJbD06JJAObH5vnCGQsmWkwgGKZluX0rILaZ47E/TBFLuUgEce0yTsmgGBcQUf0OQZ4IwoXt7vv+Y6zO1Ad86Q==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-clipboard": "^35.0.1",
+        "@ckeditor/ckeditor5-core": "^35.0.1",
+        "@ckeditor/ckeditor5-engine": "^35.0.1",
+        "@ckeditor/ckeditor5-enter": "^35.0.1",
+        "@ckeditor/ckeditor5-paragraph": "^35.0.1",
+        "@ckeditor/ckeditor5-select-all": "^35.0.1",
+        "@ckeditor/ckeditor5-typing": "^35.0.1",
+        "@ckeditor/ckeditor5-ui": "^35.0.1",
+        "@ckeditor/ckeditor5-undo": "^35.0.1",
+        "@ckeditor/ckeditor5-upload": "^35.0.1",
+        "@ckeditor/ckeditor5-utils": "^35.0.1",
+        "@ckeditor/ckeditor5-widget": "^35.0.1"
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -14265,6 +16290,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "dependencies": {
     "@acrolinx/sidebar-startpage": "^3.1.0",
     "@types/ckeditor": "4.9.10",
+    "@types/ckeditor__ckeditor5-build-balloon": "^29.1.1",
+    "@types/ckeditor__ckeditor5-build-classic": "^29.0.1",
+    "@types/ckeditor__ckeditor5-build-inline": "^29.0.0",
+    "@types/ckeditor__ckeditor5-core": "^33.0.3",
     "@types/codemirror": "0.0.106",
     "@types/diff-match-patch": "^1.0.32",
     "@types/tinymce": "^4.6.0",
@@ -33,6 +37,7 @@
   },
   "devDependencies": {
     "@acrolinx/sidebar-interface": "^15.0.0",
+    "@ckeditor/ckeditor5-build-inline": "^35.0.1",
     "@types/chai": "^4.3.0",
     "@types/draft-js": "^0.11.8",
     "@types/jquery": "^3.5.13",

--- a/test/spec/adapter-test-setups/adapter-test-setup.ts
+++ b/test/spec/adapter-test-setups/adapter-test-setup.ts
@@ -24,6 +24,6 @@ export interface AdapterTestSetup {
   inputFormat: string;
   setEditorContent: (text: string, done: DoneCallback) => void;
   init: () => Promise<AdapterInterface>;
-  remove: () => void;
+  remove: () => void | Promise<void>;
   getSelectedText(): string;
 }

--- a/test/spec/adapter-test-setups/ck5-editor.ts
+++ b/test/spec/adapter-test-setups/ck5-editor.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-present Acrolinx GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AdapterTestSetup, DoneCallback} from "./adapter-test-setup";
+import {CKEditor5Adapter} from "../../../src/adapters/CKEditor5Adapter";
+import InlineEditor from '@ckeditor/ckeditor5-build-inline';
+
+export function getCkEditorInstance(id: string): InlineEditor {
+  const editorDiv = document.querySelector('#' + id);
+  return (editorDiv as any).ckeditorInstance;
+}
+
+export class CKEditor5TestSetup implements AdapterTestSetup {
+  name = 'CKEditor5Adapter';
+  inputFormat = 'HTML';
+  editorElement = '<div id="editorId"><p>initial text</p></div>';
+
+  setEditorContent(html: string, done: DoneCallback) {
+    getCkEditorInstance('editorId').setData(html);
+    done();
+  }
+
+  async init() {
+    const editorDiv = document.querySelector('#editorId');
+    const editor = await InlineEditor.create(editorDiv as HTMLElement);
+    (<any>window).editor = editor; 
+    return new CKEditor5Adapter({editorId: "editorId"});
+  }
+
+  async remove() {
+    await getCkEditorInstance('editorId').destroy();
+    $('#editorId').remove();
+  }
+
+  getSelectedText(): string {
+    return window.getSelection()!.toString();
+  }
+
+}

--- a/test/spec/cke5adapter-adapters.ts
+++ b/test/spec/cke5adapter-adapters.ts
@@ -1,0 +1,741 @@
+/*
+ * Copyright 2022-present Acrolinx GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AbstractRichtextEditorAdapter} from '../../src';
+import {MatchWithReplacement} from '@acrolinx/sidebar-interface';
+
+import * as _ from 'lodash';
+import {isChrome} from '../../src/utils/detect-browser';
+import {waitMs} from '../utils/test-utils';
+import {
+  containsEmptyTextNodes,
+  getMatchesWithReplacement,
+  testIfWindowIsFocused
+} from '../utils/test-utils';
+import {AdapterInterface, SuccessfulContentExtractionResult} from '../../src/adapters/AdapterInterface';
+import {AdapterTestSetup} from './adapter-test-setups/adapter-test-setup';
+import {CKEditor5TestSetup} from './adapter-test-setups/ck5-editor';
+
+
+const assert = chai.assert;
+
+describe('CKEditor5 adapter test', function () {
+  const NON_BREAKING_SPACE = '\u00a0';
+
+  let adapter: AdapterInterface;
+  const DELAY_IN_MS = 50;
+
+  const dummyCheckId = 'dummyCheckId';
+
+  const adapters: AdapterTestSetup[] = [
+    new CKEditor5TestSetup(),
+  ];
+
+  const testedAdapterNames: string[] = []; // empty = all
+  const testedAdapters: AdapterTestSetup[] = adapters.filter(a => _.isEmpty(testedAdapterNames) || _.includes(testedAdapterNames, a.name));
+
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  testedAdapters.forEach(adapterSpec => {
+    const adapterName = adapterSpec.name;
+    describe('adapter ' + adapterName, function (this: any) {
+      this.timeout(10000);
+
+      beforeEach('The before each hook', function (done) {
+        $('body').append(adapterSpec.editorElement);
+        adapterSpec.init().then((res) => {
+          adapter = res;
+          done();
+        }).catch((res) => {
+          assert(false, 'Before each hook failed. ' + res);
+          done();
+        });
+      });
+
+      afterEach(async () => {
+        const containsUnwantedEmptyTextNodes = isChrome() && (adapter instanceof AbstractRichtextEditorAdapter) &&
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          containsEmptyTextNodes((adapter as any).getEditorElement());
+
+        await adapterSpec.remove();
+
+        assert.isFalse(containsUnwantedEmptyTextNodes, 'The editorElement should not contain empty text nodes');
+      });
+
+      const setEditorContent = adapterSpec.setEditorContent.bind(adapterSpec);
+
+      function assertEditorText(expectedText: string) {
+        const editorContent = (adapter.extractContentForCheck({}) as SuccessfulContentExtractionResult).content;
+        if (adapterSpec.inputFormat === 'TEXT') {
+          assert.equal(editorContent, expectedText);
+        } else {
+          const actualText = $('<div>' + editorContent + '</div>').text().replace('\n', '');
+          assert.equal(actualText, expectedText);
+        }
+      }
+
+      function registerCheckResult(text: string) {
+        adapter.registerCheckResult({
+          checkedPart: {
+            checkId: dummyCheckId,
+            range: [0, text.length]
+          }
+        });
+      }
+
+      function givenAText(text: string, callback: (initialExtractedContent: string) => void) {
+        setEditorContent(text, () => {
+          adapter.registerCheckCall({checkId: dummyCheckId});
+          const contentExtractionResult = adapter.extractContentForCheck({}) as SuccessfulContentExtractionResult;
+          registerCheckResult(text);
+          callback(contentExtractionResult.content);
+        });
+      }
+
+      function givenATextWithoutCheckResult(text: string, callback: (initialExtractedContent: string) => void) {
+        setEditorContent(text, () => {
+          adapter.registerCheckCall({checkId: dummyCheckId});
+          const contentExtractionResult = adapter.extractContentForCheck({}) as SuccessfulContentExtractionResult;
+          callback(contentExtractionResult.content);
+        });
+      }
+
+      function normalizeResultHtml(html: string) {
+        return html.replace(/\n|<span><\/span>/g, '');
+      }
+
+      it('Get initial text from editor element', function () {
+        assertEditorText('initial text');
+      });
+
+      it('Get current text from editor element', function (done) {
+        givenAText('current text', () => {
+          assertEditorText('current text');
+          done();
+        });
+      });
+
+      it('Extract initial HTML from editor element', function () {
+        assertEditorText('initial text');
+      });
+
+      it('Extract current HTML from editor element', function (done) {
+        givenAText('current text', () => {
+          assertEditorText('current text');
+          done();
+        });
+      });
+
+      it('Don\'t change surrounding words when replacing', function (done) {
+        givenAText('wordOne wordTwo wordThree', (text) => {
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordTwo', 'wordTwoReplacement'));
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordTwoReplacement wordThree');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace words in reverse order', function (done) {
+        givenAText('wordOne wordTwo wordThree', (text) => {
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordThree', 'wordThreeReplacement'));
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordTwo', 'wordTwoReplacement'));
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordTwoReplacement wordThreeReplacement');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace words in order', function (done) {
+        givenAText('wordOne wordTwo wordThree', (text) => {
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordTwo', 'wordTwoReplacement'));
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordThree', 'wordThreeReplacement'));
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordTwoReplacement wordThreeReplacement');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+          
+        });
+      });
+
+      it('Replace second of the same word', function (done) {
+        givenAText('wordOne wordSame wordSame wordThree', text => {
+          const matchWithReplacement = getMatchesWithReplacement(text, 'wordSame', 'wordSameReplacement');
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement[1]]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordSame wordSameReplacement wordThree');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace first of the same word', function (done) {
+        givenAText('wordOne wordSame wordSame wordThree', text => {
+          const matchWithReplacement = getMatchesWithReplacement(text, 'wordSame', 'wordSameReplacement');
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement[0]]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordSameReplacement wordSame wordThree');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace the same word with word in between two times with different replacements', function (done) {
+        givenAText('wordOne wordSame blubb wordSame wordThree', text => {
+          const matchWithReplacement1 = getMatchesWithReplacement(text, 'wordSame', 'wordSameReplacement1');
+          const matchWithReplacement2 = getMatchesWithReplacement(text, 'wordSame', 'wordSameReplacement2');
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement1[0]]);
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement2[1]]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordSameReplacement1 blubb wordSameReplacement2 wordThree');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace the same word two times with different replacements', function (done) {
+        givenAText('wordOne wordSame wordSame wordThree', text => {
+          const matchWithReplacement1 = getMatchesWithReplacement(text, 'wordSame', 'wordSame1');
+          const matchWithReplacement2 = getMatchesWithReplacement(text, 'wordSame', 'wordSame2');
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement1[0]]);
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement2[1]]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordSame1 wordSame2 wordThree');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+
+      it('Replace the same word two times with different replacements, where the first replacement is kinda long', function (done) {
+        givenAText('wordOne wordSame wordSame wordThree', text => {
+          const matchWithReplacement1 = getMatchesWithReplacement(text, 'wordSame', 'wordSamelonglonglonglong1');
+          const matchWithReplacement2 = getMatchesWithReplacement(text, 'wordSame', 'wordSame2');
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement1[0]]);
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement2[1]]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordSamelonglonglonglong1 wordSame2 wordThree');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace the same word two times with different replacements in reverse oder', function (done) {
+        givenAText('wordOne wordSame wordSame wordThree', text => {
+          const matchWithReplacement1 = getMatchesWithReplacement(text, 'wordSame', 'wordSame1');
+          const matchWithReplacement2 = getMatchesWithReplacement(text, 'wordSame', 'wordSame2');
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement2[1]]);
+          adapter.replaceRanges(dummyCheckId, [matchWithReplacement1[0]]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordSame1 wordSame2 wordThree');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace single character ","', function (done) {
+        givenAText('wordOne, wordTwo', text => {
+          const matchWithReplacement = getMatchesWithReplacement(text, ',', '');
+          adapter.replaceRanges(dummyCheckId, matchWithReplacement);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordTwo');
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+          done();
+        });
+      });
+
+      it('Replace single character space', function (done) {
+        givenAText('wordOne wordTwo', text => {
+          const matchWithReplacement = getMatchesWithReplacement(text, ' ', '');
+          adapter.replaceRanges(dummyCheckId, matchWithReplacement);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOnewordTwo');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace continues multi range', function (done) {
+        givenAText('word0 blub mist word3', text => {
+          const word1 = getMatchesWithReplacement(text, 'blub', 'a')[0];
+          const word2 = getMatchesWithReplacement(text, 'mist', 'b')[0];
+          const space = {
+            content: ' ',
+            replacement: '',
+            range: [word1.range[1], word2.range[0]] as [number, number]
+          };
+
+          adapter.replaceRanges(dummyCheckId, [word1, space, word2]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('word0 ab word3');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace continues multi range with number in words', function (done) {
+        givenAText('word0 blub1 mist2 word3', text => {
+
+          const word1 = getMatchesWithReplacement(text, 'blub1', 'a')[0];
+          const word2 = getMatchesWithReplacement(text, 'mist2', 'b')[0];
+          const space = {
+            content: ' ',
+            replacement: '',
+            range: [word1.range[1], word2.range[0]] as [number, number]
+          };
+
+          adapter.replaceRanges(dummyCheckId, [word1, space, word2]);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('word0 ab word3');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace first and only char', function (done) {
+        givenAText('x', text => {
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'x', 'aa'));
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('aa');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace first and only word', function (done) {
+        givenAText('xyz', async text => {
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'xyz', 'aa'));
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('aa');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace first char', function (done) {
+        givenAText('x after', text => {
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'x', 'aa'));
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('aa after');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace first word', function (done) {
+        givenAText('xyz after', text => {
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'xyz', 'aa'));
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('aa after');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace single chars', function (done) {
+        givenAText('y x f z u', text => {
+
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'x', 'aa'));
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'f', 'bb'));
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'z', 'cc'));
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'u', 'dd'));
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('y aa bb cc dd');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace inside a word', function (done) {
+        givenAText('InsideAllWord', text => {
+
+          const matchWithReplacement = getMatchesWithReplacement(text, 'All', '12345');
+          adapter.replaceRanges(dummyCheckId, matchWithReplacement);
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('Inside12345Word');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace last word', function (done) {
+        givenAText('wordOne wordTwo', text => {
+
+          const matchesWithReplacement = getMatchesWithReplacement(text, 'wordTwo', 'wordTw');
+          adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne wordTw');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace last word with short word', function (done) {
+        givenAText('wordOne wordTwo', text => {
+
+          const matchesWithReplacement = getMatchesWithReplacement(text, 'wordTwo', 'beer');
+          adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('wordOne beer');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+
+      it('Replace discontinues multi range', function (done) {
+        givenAText('wordOne wordTwo wordThree wordFour', text => {
+          const matchesWithReplacement = [
+            getMatchesWithReplacement(text, 'wordOne', 'a')[0],
+            getMatchesWithReplacement(text, 'wordThree', 'c')[0]
+          ];
+          adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText('a wordTwo c wordFour');
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace with and after strange chars', function (done) {
+        givenAText('wordOne wordTwo wordThree wordFour', text => {
+          const strangeChars = '[]()/&%$§"!\'*+~öäü:,;-<>|^°´`òê€@ß?={}µコンピュータ';
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordTwo', strangeChars));
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordThree', 'c'));
+          // TODO: Depending on the document type, we should test for correct escaping.
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText(`wordOne ${ strangeChars } c wordFour`);
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace with text looking like entities', function (done) {
+        givenAText('wordOne wordTwo wordThree', text => {
+          const entities = '&uuml;';
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordTwo', entities));
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText(`wordOne ${ entities } wordThree`);
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace with text looking like html tags', function (done) {
+        givenAText('wordOne wordTwo wordThree', text => {
+          const replacement = '<tagish>';
+          adapter.replaceRanges(dummyCheckId, getMatchesWithReplacement(text, 'wordTwo', replacement));
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText(`wordOne ${ replacement } wordThree`);
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('Replace word containing entity', function (done) {
+        givenAText('wordOne D&amp;D wordThree', html => {
+          const replacement = 'Dungeons and Dragons';
+          const matchesWithReplacement = getMatchesWithReplacement(html, 'D&amp;D', replacement);
+          matchesWithReplacement[0].content = 'D&D';
+          adapter.selectRanges(dummyCheckId, matchesWithReplacement);
+          adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText(`wordOne ${ replacement } wordThree`);
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+        
+      });
+
+      if (adapterSpec.inputFormat === 'HTML') {
+        it('Replace word before entity &nbsp;', function (done) {
+          givenAText('Southh&nbsp;is warm.', html => {
+            const replacement = 'South';
+            const matchesWithReplacement = getMatchesWithReplacement(html, 'Southh', replacement);
+            adapter.selectRanges(dummyCheckId, matchesWithReplacement);
+            adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+            waitMs(DELAY_IN_MS).then(() => {
+              assertEditorText(`${ replacement }${ NON_BREAKING_SPACE }is warm.`);
+              done();
+            }).catch(() => {
+              assert(false, 'Unable to synchronize with replacement event');
+              done();
+            });
+          });
+        });
+
+        it('Replace words containing entity &nbsp;', function (done) {
+          givenAText('South&nbsp;is warm&nbsp;.', html => {
+            const replacement = 'South';
+            // Some editors wrap the html inside e.g. <p>
+            const offset = html.indexOf('South');
+            const matchesWithReplacement = [
+              {content: 'warm', range: [14 + offset, 18 + offset], replacement: 'warm.'},
+              {content: NON_BREAKING_SPACE, range: [18 + offset, 24 + offset], replacement: ''},
+              {content: '.', range: [24 + offset, 25 + offset], replacement: ''},
+            ] as MatchWithReplacement[];
+            adapter.selectRanges(dummyCheckId, matchesWithReplacement);
+            adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+            waitMs(DELAY_IN_MS).then(() => {
+              assertEditorText(`${ replacement }${ NON_BREAKING_SPACE }is warm.`);
+              done();
+            }).catch(() => {
+              assert(false, 'Unable to synchronize with replacement event');
+              done();
+            });
+          });
+        });
+      }
+
+      it('Replace same word in correct order', function (done) {
+        givenAText('before wordSame wordSame wordSame wordSame wordSame after', text => {
+          // The diff approach can not always handle ["a", "b", "c", "d", "e"] correctly.
+          const replacements = ['replacement1', 'replacement2', 'replacement3', 'replacement4', 'replacement5'];
+
+          function replace(i: number) {
+            adapter.replaceRanges(dummyCheckId, [getMatchesWithReplacement(text, 'wordSame', replacements[i])[i]]);
+          }
+
+          replace(0);
+          replace(4);
+          replace(2);
+          replace(3);
+          replace(1);
+
+          waitMs(DELAY_IN_MS).then(() => {
+            assertEditorText(`before ${ replacements.join(' ') } after`);
+            done();
+          }).catch(() => {
+            assert(false, 'Unable to synchronize with replacement event');
+            done();
+          });
+        });
+      });
+
+      it('selectRanges does not change text', function (done) {
+        const words = ['wordOne', 'wordTwo', 'wordThree', 'wordFour'];
+        const editorText = words.join(' ');
+        givenAText(editorText, text => {
+          words.forEach((word) => {
+            adapter.selectRanges(dummyCheckId, getMatchesWithReplacement(text, word, ''));
+          });
+
+          adapter.selectRanges(dummyCheckId, [
+            getMatchesWithReplacement(text, words[0], '')[0],
+            getMatchesWithReplacement(text, words[words.length - 1], '')[0]
+          ]);
+
+          adapter.selectRanges(dummyCheckId, [
+            getMatchesWithReplacement(text, words[1], '')[0],
+            getMatchesWithReplacement(text, words[2], '')[0]
+          ]);
+
+          assertEditorText(editorText);
+          done();
+        });
+      });
+
+      if (adapterSpec.inputFormat === 'HTML') {
+        it('Remove complete text content', function (done) {
+          givenAText('<p>a</p>', () => {
+            const matchesWithReplacement: MatchWithReplacement[] = [
+              {'content': 'a', 'range': [3, 4], 'replacement': ''},
+            ];
+            adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+
+            waitMs(DELAY_IN_MS).then(() => {
+              done();
+            }).catch(() => {
+              assert(false, 'Unable to synchronize with replacement event');
+              done();
+            });
+          });
+        });
+
+
+        it.skip('Missing space within divs', function (done) {
+          givenAText('<div>a b ?</div><div>c</div>', () => {
+            const matchesWithReplacement: MatchWithReplacement[] = [
+              {'content': 'b', 'range': [7, 8], 'replacement': 'b?'},
+              {'content': ' ', 'range': [8, 9], 'replacement': ''},
+              {'content': '?', 'range': [9, 10], 'replacement': ''}];
+            adapter.replaceRanges(dummyCheckId, matchesWithReplacement);
+
+            waitMs(DELAY_IN_MS).then(() => {
+              assert.equal(normalizeResultHtml(adapter.getContent!({})), '<div>a b?</div><div>c</div>');
+              done();
+            }).catch(() => {
+              assert(false, 'Unable to synchronize with replacement event');
+              done();
+            });
+          });
+        });
+
+      }
+
+      it('SelectRanges throws exception if matched document part has changed', function (done) {
+        givenAText('wordOne wordTwo wordThree', html => {
+          const matchesWithReplacement = getMatchesWithReplacement(html, 'wordTwo');
+          setEditorContent('wordOne wordXTwo wordThree', () => {
+            assert.throws(() => adapter.selectRanges(dummyCheckId, matchesWithReplacement));
+            done();
+          });
+        });
+      });
+
+      it('ReplaceRanges throws exception if matched document part has changed', function (done) {
+        givenAText('wordOne wordTwo wordThree', html => {
+          const matchesWithReplacement = getMatchesWithReplacement(html, 'wordTwo', 'replacement');
+          setEditorContent('wordOne wordXTwo wordThree', () => {
+            assert.throws(() => adapter.replaceRanges(dummyCheckId, matchesWithReplacement));
+
+            waitMs(DELAY_IN_MS).then(() => {
+              done();
+            }).catch(() => {
+              assert(false, 'Unable to synchronize with replacement event');
+              done();
+            });
+          });
+        });
+      });
+
+      describe('selectRanges', () => {
+        testIfWindowIsFocused('should select the correct text', (done) => {
+          const completeContent = '<p>begin selection end</p>';
+          givenAText(completeContent, initialExtractedContent => {
+            const matchesWithReplacement = getMatchesWithReplacement(initialExtractedContent, 'selection');
+            adapter.selectRanges(dummyCheckId, matchesWithReplacement);
+            assert.equal(adapterSpec.getSelectedText(), 'selection');
+            done();
+          });
+        });
+      });
+
+      describe('previous successful check, but current check has not finished', () => {
+        let matchesWithReplacementOfFirstCheck: MatchWithReplacement[];
+        beforeEach((done) => {
+          const completeContent = 'begin selection end';
+          givenAText(completeContent, initialExtractedContent => {
+            matchesWithReplacementOfFirstCheck = getMatchesWithReplacement(initialExtractedContent, 'selection', 'replacement');
+            done();
+          });
+        });
+
+        it('replaces ranges of previous check', (done) => {
+          const completeNewContent = 'change begin selection end';
+          givenATextWithoutCheckResult(completeNewContent, _initialExtractedContent => {
+            adapter.replaceRanges(dummyCheckId, matchesWithReplacementOfFirstCheck);
+
+            waitMs(DELAY_IN_MS).then(() => {
+              assertEditorText('change begin replacement end');
+              done();
+            }).catch(() => {
+              assert(false, 'Unable to synchronize with replacement event');
+              done();
+            });
+          });
+        });
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
# Improvements for CKEditor 5

## Test Setup

- Added new test setup for CK5
- Setup Includes Inline CK5 Editor
- Added extraction, selection and replacement tests

## Modification to Adapter

### Created separate Adapter for CK5

- Reasons: CK4 and CK5 instances are different and cannot be interchangeably used.
- The current adapter only return CK4 instance even for Ck5 which is incorrect and can cause confusion to external developer. It causes compilation issue if developer wishes to develop with CK5 (This is not a runtime issue due to nature of JS).
- Every function in CK4 needed to be if--else by checking editorVersion, which induces that there is no common functionality.
- Also it can fail if Ck4 and Ck5 exist on same page (This is though a rare thing, but encountered it in tests)

### The new CK5 Adapter

- Only responsible for CK5
- Returns CK5 editor instances