### PR TITLE
DEV-25433 Limit NPM publish, tag and pages to run on main (#35)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,17 +70,18 @@ jobs:
       - name: Publish to NPM
         id: publish
         uses: JS-DevTools/npm-publish@v1
+        if: github.ref == 'refs/heads/main'
         with:
           token: ${{ secrets.NPM_ACCESS_TOKEN }}
       
       - name: Push tag
         uses: anothrNick/github-tag-action@1.36.0
-        if: steps.publish.outputs.type != 'none'
+        if: github.ref == 'refs/heads/main' && steps.publish.outcome == 'success' && steps.publish.outputs.type != 'none'
         env:
           CUSTOM_TAG: v${{ steps.publish.outputs.version }}
       
       - name: Publish github pages 🚀
-        if: steps.publish.outputs.type != 'none'
+        if: github.ref == 'refs/heads/main' && steps.publish.outcome == 'success' && steps.publish.outputs.type != 'none'
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages


### PR DESCRIPTION
* DEV-25433; chore: update readme

* DEV-25433; fix: type ambiguity, add exports

* DEV-25433; fix: only run publish on main

* DEV-25433; fix: run tag and pages only on main and publish succeeds

* DEV-25433; fix: string quote

* DEV-25433; fix: redundant &&