### PR TITLE
chore: update post publish to use changed output types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -76,12 +78,12 @@ jobs:
       
       - name: Push tag
         uses: anothrNick/github-tag-action@1.67.0
-        if: github.ref == 'refs/heads/main' && steps.publish.outcome == 'success' && steps.publish.outputs.type != 'none'
+        if: github.ref == 'refs/heads/main' && steps.publish.outputs.type
         env:
           CUSTOM_TAG: v${{ steps.publish.outputs.version }}
       
       - name: Publish github pages 🚀
-        if: github.ref == 'refs/heads/main' && steps.publish.outcome == 'success' && steps.publish.outputs.type != 'none'
+        if: github.ref == 'refs/heads/main' && steps.publish.outputs.type
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           branch: gh-pages


### PR DESCRIPTION
Post publish actions are updated to new major versions.

Refer action output for details: https://github.com/JS-DevTools/npm-publish?tab=readme-ov-file#action-output

Refer https://github.com/JS-DevTools/npm-publish?tab=readme-ov-file#action-output for permission update