### PR TITLE
DEV-41993; fix:  provide accurate payload to InputEvent constructor

### DIFF
--- a/src/adapters/AbstractRichtextEditorAdapter.ts
+++ b/src/adapters/AbstractRichtextEditorAdapter.ts
@@ -204,13 +204,13 @@ export abstract class AbstractRichtextEditorAdapter implements AdapterInterface 
         const head = this.createRange(match.range[0], 1, textDomMapping);
         const completeRange = this.createRange(match.range[0], rangeLength, textDomMapping);
 
-        const { startOffset, endOffset } = completeRange;
         simulateInputEvent({
-          node: completeRange.startContainer,
+          startNode: completeRange.startContainer,
+          endNode: completeRange.endContainer,
           eventType: 'beforeinput',
           replacement: match.originalMatch.replacement,
-          startOffset,
-          endOffset,
+          startOffset: completeRange.startOffset,
+          endOffset: completeRange.endOffset,
           disableSimulation: this.config.disableInputEventSimulation,
         });
 
@@ -221,11 +221,12 @@ export abstract class AbstractRichtextEditorAdapter implements AdapterInterface 
         }
 
         simulateInputEvent({
-          node: completeRange.startContainer,
+          startNode: completeRange.startContainer,
+          endNode: completeRange.endContainer,
           eventType: 'input',
           replacement: match.originalMatch.replacement,
-          startOffset,
-          endOffset,
+          startOffset: completeRange.startOffset,
+          endOffset: completeRange.endOffset,
           disableSimulation: this.config.disableInputEventSimulation,
         });
 
@@ -236,13 +237,13 @@ export abstract class AbstractRichtextEditorAdapter implements AdapterInterface 
       } else {
         const range = this.createRange(match.range[0], rangeLength, textDomMapping);
 
-        const { startOffset, endOffset } = range;
         simulateInputEvent({
-          node: range.startContainer,
+          startNode: range.startContainer,
+          endNode: range.endContainer,
           eventType: 'beforeinput',
           replacement: match.originalMatch.replacement,
-          startOffset,
-          endOffset,
+          startOffset: range.startOffset,
+          endOffset: range.endOffset,
           disableSimulation: this.config.disableInputEventSimulation,
         });
 
@@ -252,11 +253,12 @@ export abstract class AbstractRichtextEditorAdapter implements AdapterInterface 
         }
 
         simulateInputEvent({
-          node: range.startContainer,
+          startNode: range.startContainer,
+          endNode: range.endContainer,
           eventType: 'input',
           replacement: match.originalMatch.replacement,
-          startOffset,
-          endOffset,
+          startOffset: range.startOffset,
+          endOffset: range.endOffset,
           disableSimulation: this.config.disableInputEventSimulation,
         });
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -47,7 +47,8 @@ export function isIFrame(el: Element): el is HTMLIFrameElement {
 }
 
 export type SimulateInputEventProps = {
-  node: Node;
+  startNode: Node;
+  endNode: Node;
   eventType: string;
   startOffset: number;
   endOffset: number;
@@ -56,14 +57,14 @@ export type SimulateInputEventProps = {
 };
 
 export function simulateInputEvent(props: SimulateInputEventProps) {
-  const { node, eventType, startOffset, endOffset, replacement, disableSimulation } = props;
+  const { startNode: startNode, endNode: endNode, eventType, startOffset, endOffset, replacement, disableSimulation } = props;
   if (disableSimulation) {
     return;
   }
   const staticRange: StaticRange = new StaticRange({
-    startContainer: node,
+    startContainer: startNode,
     startOffset,
-    endContainer: node,
+    endContainer: endNode,
     endOffset,
   });
 
@@ -75,7 +76,7 @@ export function simulateInputEvent(props: SimulateInputEventProps) {
     targetRanges: [staticRange],
   };
 
-  node.dispatchEvent(new InputEvent(eventType, eventOptions));
+  startNode.dispatchEvent(new InputEvent(eventType, eventOptions));
 }
 
 export function parseUrl(href: string) {


### PR DESCRIPTION
## Build failing

Starting from Chrome v133 our SDK pipeline started failing suddenly...Oh no.... 🤔 

## Background:

For replacements, we need to simulate input events, so modern editors understand that they need to trigger save or send API request to the cloud to propagate changes.

These input events serve the purpose of invoking save handlers in the editors, the payload of these events really doesn't matter.

So until now we just created input events with redundant data, like using same node for start and end, and also the InputEvent constructor did not really check if the data is accurate.

In Chrome v133 this changes. the InputEvent constructor validates the event payload. So sending arbitary nodes and ranges in our cases start node and offsets for both start and end.

As the constructor started validating the event payload it threw `IndexSizeError: Failed to construct 'InputEvent'` error.

## How did I know this has changed in chromium, where can I find it?

We can look for the Input Event constructor in Chromium C language code.
Wait what? As a JS developer do I have to look at Chromium C code? Yes, sometimes. 😆 

These are core stuff and don't usually get updated, so change in this code made me curious.

I could find a commit which explains what changes chromium authors have done and it exactly points to our use case
https://source.chromium.org/chromium/chromium/src/+/2bcae7b59c7b4e2729905b846a6181798671b7e4

The commit author writes

```text
Propagate Range exceptions through InputEvent::Create.

When InputEvent's constructor is given StaticRange objects, converting
those objects to Range objects might throw an exception.  Currently in
those cases we have a DCHECK failure in DCHECK-enabled builds, and store
a default-initialized range (pointing to the Document) in non-DCHECK
builds.

This instead propagates those exceptions through the InputEvent
constructor.

It's not really clear what the spec requires since the spec isn't clear
about the processing model for this InputEvent constructor; in
particular the fact that we store these ranges as Range rather than
StaticRange is unclear in the spec.

This is a behavior change, but only for an obscure corner of the spec
(manually-initialized events) that didn't work correctly before.

The added test fails without the change (crashing in DCHECK-enabled
builds, and failing in non-DCHECK-enabled builds).
```



in the sentence "_**This instead propagates those exceptions through the InputEvent
constructor.**_" is what causes error in our code and tests.

Also we can see in the chromium code with this commit exception state is set for invalid target ranges

Commit:
https://source.chromium.org/chromium/chromium/src/+/2bcae7b59c7b4e2729905b846a6181798671b7e4:third_party/blink/renderer/core/events/input_event.cc;dlc=1647d7b32546e02801a744bd6865efd2760d19c1

![Screenshot 2025-02-26 at 13 54 41](https://github.com/user-attachments/assets/7395bbfc-e27b-4e29-a1c6-77baca280d49)


## Solution:

Give the InputEvent constructor what it needs, accurate payload !!