### PR TITLE
Use sonarqube-scan-action instead of sonarcloud-github-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v4
+        uses: sonarsource/sonarqube-scan-action@v4
         with:
           args: -Dsonar.organization=acrolinx
         env:


### PR DESCRIPTION
The [sonarcloud-github-action](https://github.com/sonarsource/sonarcloud-github-action) is deprecated.